### PR TITLE
favicon

### DIFF
--- a/bifrost-fastify/package.json
+++ b/bifrost-fastify/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@alignable/bifrost-fastify",
   "repository": "https://github.com/Alignable/bifrost.git",
-  "version": "0.0.17",
+  "version": "0.0.18",
   "type": "module",
   "main": "./dist/index.js",
   "types": "./dist/index.d.ts",
@@ -18,7 +18,7 @@
     "vite": "^4.0.3"
   },
   "peerDependencies": {
-    "@alignable/bifrost": "0.0.17",
+    "@alignable/bifrost": "0.0.18",
     "fastify": "^4.9.2",
     "vite-plugin-ssr": "0.4.131-commit-35ca471f7"
   },

--- a/bifrost/package.json
+++ b/bifrost/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@alignable/bifrost",
   "repository": "https://github.com/Alignable/bifrost.git",
-  "version": "0.0.17",
+  "version": "0.0.18",
   "type": "module",
   "types": "./dist/index.d.ts",
   "exports": {

--- a/bifrost/renderer/+config.ts
+++ b/bifrost/renderer/+config.ts
@@ -19,5 +19,6 @@ export default {
     layoutProps: { env: "server-and-client" },
     documentProps: { env: "server-and-client" },
     scripts: { env: "server-and-client" },
+    favicon: { env: "server-only" },
   },
 } satisfies ConfigNonHeaderFile;

--- a/bifrost/renderer/onRenderHtml.tsx
+++ b/bifrost/renderer/onRenderHtml.tsx
@@ -39,9 +39,15 @@ export default async function onRenderHtml(
     )
   );
 
+  const { favicon } = pageContext.config;
+  const faviconTag = !favicon
+    ? ""
+    : escapeInject`<link rel="icon" href="${favicon}" />`;
+
   const documentHtml = escapeInject`<!DOCTYPE html>
     <html lang="en">
       <head>
+      ${faviconTag}
       ${dangerouslySkipEscape(headHtml)}
       ${dangerouslySkipEscape(
         Object.values(pageContext.config.scripts || {}).join("")

--- a/bifrost/types/internal.ts
+++ b/bifrost/types/internal.ts
@@ -92,6 +92,7 @@ export type NoProxyConfig = ConfigConstructor<
     layoutProps: AugmentMe.LayoutProps;
     documentProps: DocumentProps;
     scripts: string[];
+    favicon: string;
   }
 >;
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -16,7 +16,7 @@
     },
     "bifrost": {
       "name": "@alignable/bifrost",
-      "version": "0.0.17",
+      "version": "0.0.18",
       "dependencies": {
         "cross-env": "^7.0.3",
         "jsdom": "^22.1.0",
@@ -46,7 +46,7 @@
     },
     "bifrost-fastify": {
       "name": "@alignable/bifrost-fastify",
-      "version": "0.0.17",
+      "version": "0.0.18",
       "dependencies": {
         "@fastify/accepts": "^4.1.0",
         "@fastify/forwarded": "^2.2.0",
@@ -72,7 +72,7 @@
         "typescript": "^5.0.4"
       },
       "peerDependencies": {
-        "@alignable/bifrost": "0.0.17",
+        "@alignable/bifrost": "0.0.18",
         "fastify": "^4.9.2",
         "vite-plugin-ssr": "0.4.131-commit-35ca471f7"
       }

--- a/tests/vite/package.json
+++ b/tests/vite/package.json
@@ -4,8 +4,10 @@
   "description": "",
   "scripts": {
     "dev": "nodemon server/index.ts",
-    "start": "ts-node server/index.ts",
-    "build": "vite build"
+    "start": "yarn node dist/server/index.js",
+    "build": "yarn build:server && yarn build:vite",
+    "build:vite": "vite build --outDir dist/vite",
+    "build:server": "yarn tsc -p tsconfig-build.json"
   },
   "type": "module",
   "author": "",

--- a/tests/vite/server/index.ts
+++ b/tests/vite/server/index.ts
@@ -25,10 +25,10 @@ async function startServer() {
 
   if (isProduction) {
     console.log("Running in production mode");
-    const distPath = path.join(root, "/dist/client/assets");
+    const distPath = path.join(root, "/vite/client/assets");
     app.register(fastifyStatic, {
       root: distPath,
-      prefix: "/assets/",
+      prefix: "/bifrost-assets/assets/",
     });
   } else {
     const vite = await import("vite");


### PR DESCRIPTION
favicon support needs to be baked into bifrost because importing the svg inside config.h.ts just returns the funky "import:../assets/..." string that Vike uses. only within onRenderHtml is it resolved. I think its pretty reasonable to have in bifrost though