### PR TITLE
redirect trailing slashes

### DIFF
--- a/bifrost-fastify/index.ts
+++ b/bifrost-fastify/index.ts
@@ -85,9 +85,11 @@ export const viteProxyPlugin: FastifyPluginAsync<
     upstream: upstream.href,
     async preHandler(req, reply) {
       if (req.method === "GET" && req.accepts().type(["html"]) === "html") {
-        if (req.url.endsWith('/')) {
+        const trailingSlash = /\/(\?|#|$)/;
+
+        if (trailingSlash.test(req.url)) {
           req.log.info("bifrost: redirecting trailing slash");
-          reply.redirect(301, req.url.slice(0, -1));
+          reply.redirect(301, req.url.replace(trailingSlash, "\$1"));
           return;
         }
 

--- a/bifrost-fastify/index.ts
+++ b/bifrost-fastify/index.ts
@@ -94,6 +94,12 @@ export const viteProxyPlugin: FastifyPluginAsync<
           { _pageId: string },
           typeof pageContextInit
         >(pageContextInit);
+        
+        if (req.url.endsWith('/')) {
+          req.log.info("bifrost: redirecting trailing slash");
+          reply.redirect(301, req.url.slice(0, -1));
+          return;
+        }
 
         const proxy = pageContext._pageId === proxyPageId;
         const noRouteMatched =

--- a/bifrost-fastify/index.ts
+++ b/bifrost-fastify/index.ts
@@ -85,6 +85,12 @@ export const viteProxyPlugin: FastifyPluginAsync<
     upstream: upstream.href,
     async preHandler(req, reply) {
       if (req.method === "GET" && req.accepts().type(["html"]) === "html") {
+        if (req.url.endsWith('/')) {
+          req.log.info("bifrost: redirecting trailing slash");
+          reply.redirect(301, req.url.slice(0, -1));
+          return;
+        }
+
         const pageContextInit = {
           urlOriginal: req.url,
           ...(buildPageContextInit ? await buildPageContextInit(req) : {}),
@@ -94,12 +100,6 @@ export const viteProxyPlugin: FastifyPluginAsync<
           { _pageId: string },
           typeof pageContextInit
         >(pageContextInit);
-        
-        if (req.url.endsWith('/')) {
-          req.log.info("bifrost: redirecting trailing slash");
-          reply.redirect(301, req.url.slice(0, -1));
-          return;
-        }
 
         const proxy = pageContext._pageId === proxyPageId;
         const noRouteMatched =

--- a/bifrost-fastify/package.json
+++ b/bifrost-fastify/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@alignable/bifrost-fastify",
   "repository": "https://github.com/Alignable/bifrost.git",
-  "version": "0.0.21",
+  "version": "0.0.22",
   "type": "module",
   "main": "./dist/index.js",
   "types": "./dist/index.d.ts",
@@ -18,7 +18,7 @@
     "vite": "^4.0.3"
   },
   "peerDependencies": {
-    "@alignable/bifrost": "0.0.21",
+    "@alignable/bifrost": "0.0.22",
     "fastify": "^4.9.2",
     "vite-plugin-ssr": "0.4.131-commit-35ca471f7"
   },

--- a/bifrost/package.json
+++ b/bifrost/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@alignable/bifrost",
   "repository": "https://github.com/Alignable/bifrost.git",
-  "version": "0.0.21",
+  "version": "0.0.22",
   "type": "module",
   "types": "./dist/index.d.ts",
   "exports": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -16,7 +16,7 @@
     },
     "bifrost": {
       "name": "@alignable/bifrost",
-      "version": "0.0.21",
+      "version": "0.0.22",
       "dependencies": {
         "cross-env": "^7.0.3",
         "jsdom": "^22.1.0",
@@ -46,7 +46,7 @@
     },
     "bifrost-fastify": {
       "name": "@alignable/bifrost-fastify",
-      "version": "0.0.21",
+      "version": "0.0.22",
       "dependencies": {
         "@fastify/accepts": "^4.1.0",
         "@fastify/forwarded": "^2.2.0",
@@ -72,7 +72,7 @@
         "typescript": "^5.0.4"
       },
       "peerDependencies": {
-        "@alignable/bifrost": "0.0.21",
+        "@alignable/bifrost": "0.0.22",
         "fastify": "^4.9.2",
         "vite-plugin-ssr": "0.4.131-commit-35ca471f7"
       }

--- a/tests/alb/index.js
+++ b/tests/alb/index.js
@@ -9,6 +9,7 @@ const BIFROST_PATHS = [
   "/custom-incorrect",
   "/react-body-script-injection",
   "/head-test",
+  "/this-is-a-custom-route",
 ];
 
 proxy.addResolver((host, url, req) => {

--- a/tests/e2e/specs/e2e.spec.ts
+++ b/tests/e2e/specs/e2e.spec.ts
@@ -69,12 +69,28 @@ test.describe("pages", () => {
     await page.getByText("legacy page").click();
     await expect(page.getByText("React Body")).toHaveCount(1);
   });
+});
 
-  test("it redirects trailing slashes with custom routes", async ({ page }) => {
+test.describe("trailing slashes on custom routes", () => { 
+  test("redirects to no slash", async ({ page }) => {
     await page.goto("./this-is-a-custom-route/");
-    
+
     await expect(page).toHaveTitle("custom route");
     await expect(page).toHaveURL("/this-is-a-custom-route")
+  });
+
+  test("redirects with query parameter", async ({ page }) => {
+    await page.goto("./this-is-a-custom-route/?abc=1");
+
+    await expect(page).toHaveTitle("custom route");
+    await expect(page).toHaveURL("/this-is-a-custom-route?abc=1")
+  });
+
+  test("redirects with hash", async ({ page }) => {
+    await page.goto("./this-is-a-custom-route/#abc");
+
+    await expect(page).toHaveTitle("custom route");
+    await expect(page).toHaveURL("/this-is-a-custom-route#abc")
   });
 });
 
@@ -147,7 +163,7 @@ test.describe("redirects", () => {
     expect(page.url()).toContain(`${baseURL}/custom`);
   });
 
-  test("sets cookies along the way", async ({ page, context, baseURL }) => {
+  test("sets cookivscode-file://vscode-app/private/var/folders/d0/91p61hw13m3_yw_xkmk81y3r0000gn/T/AppTranslocation/DAE110AD-D37C-4DB8-97EC-F2FBF0DEE34C/d/Visual%20Studio%20Code.app/Contents/Resources/app/out/vs/code/electron-sandbox/workbench/workbench.htmles along the way", async ({ page, context, baseURL }) => {
     const customProxy = new CustomProxyPage(page, {
       title: "first page",
       links: [

--- a/tests/e2e/specs/e2e.spec.ts
+++ b/tests/e2e/specs/e2e.spec.ts
@@ -163,7 +163,7 @@ test.describe("redirects", () => {
     expect(page.url()).toContain(`${baseURL}/custom`);
   });
 
-  test("sets cookivscode-file://vscode-app/private/var/folders/d0/91p61hw13m3_yw_xkmk81y3r0000gn/T/AppTranslocation/DAE110AD-D37C-4DB8-97EC-F2FBF0DEE34C/d/Visual%20Studio%20Code.app/Contents/Resources/app/out/vs/code/electron-sandbox/workbench/workbench.htmles along the way", async ({ page, context, baseURL }) => {
+  test("sets cookies along the way", async ({ page, context, baseURL }) => {
     const customProxy = new CustomProxyPage(page, {
       title: "first page",
       links: [

--- a/tests/e2e/specs/e2e.spec.ts
+++ b/tests/e2e/specs/e2e.spec.ts
@@ -69,6 +69,13 @@ test.describe("pages", () => {
     await page.getByText("legacy page").click();
     await expect(page.getByText("React Body")).toHaveCount(1);
   });
+
+  test("it redirects trailing slashes with custom routes", async ({ page }) => {
+    await page.goto("./this-is-a-custom-route/");
+    
+    await expect(page).toHaveTitle("custom route");
+    await expect(page).toHaveURL("/this-is-a-custom-route")
+  });
 });
 
 test("it keeps the favicon between pages", async ({ page }) => {

--- a/tests/vite/pages/custom-route-page/+Page.tsx
+++ b/tests/vite/pages/custom-route-page/+Page.tsx
@@ -1,0 +1,23 @@
+import React from "react";
+
+const CUSTOM_HREF = {
+  title: "legacy page",
+  content: "legacy body",
+  headScripts: ["inline1", "blocking", "defer"],
+  bodyScripts: ["blocking", "inline1", "inline2", "blocking"],
+};
+
+export default function Page() {
+  return (
+    <>
+      <h1>Custom Route</h1>
+      <a href={`/custom?page=${encodeURI(JSON.stringify(CUSTOM_HREF))}`}>
+        legacy page
+      </a>
+      <a href="/react-body-script-injection">
+        react body
+      </a>
+      <a href="/head-test">head test</a>
+    </>
+  );
+}

--- a/tests/vite/pages/custom-route-page/+config.ts
+++ b/tests/vite/pages/custom-route-page/+config.ts
@@ -1,0 +1,10 @@
+import { MainNavLayout } from "../../layouts/MainNavLayout";
+import { BifrostConfig } from "@alignable/bifrost";
+
+export default {
+  Layout: MainNavLayout,
+  layoutProps: { currentNav: "tmp" },
+  documentProps: {
+    title: "custom route",
+  },
+} satisfies BifrostConfig;

--- a/tests/vite/pages/custom-route-page/+route.ts
+++ b/tests/vite/pages/custom-route-page/+route.ts
@@ -1,0 +1,6 @@
+import type { PageContextBuiltIn } from "vite-plugin-ssr/types";
+
+const ROUTES = ["/this-is-a-custom-route"];
+export default function route(pageContext: PageContextBuiltIn) {
+  return ROUTES.includes(pageContext.urlPathname);
+}


### PR DESCRIPTION
This PR is meant to address an issue with trailing slashes not being redirected when we were using custom routing (ie `+route.ts` ), and right now you can actually get to the old rails pages by using a trailing slash (https://www.alignable.com/about/). Solution was to just redirect those routes in `bifrost-fastify`