### PR TITLE
Upgrade VPS => Vike

### DIFF
--- a/bifrost-fastify/index.ts
+++ b/bifrost-fastify/index.ts
@@ -1,4 +1,4 @@
-// Note that this file isn't processed by Vite, see https://github.com/brillout/vite-plugin-ssr/issues/562
+// Note that this file isn't processed by Vite, see https://github.com/brillout/vike/issues/562
 import { FastifyReply, RawServerBase, FastifyPluginAsync } from "fastify";
 import { FastifyRequest, RequestGenericInterface } from "fastify/types/request";
 import proxy from "@fastify/http-proxy";
@@ -10,7 +10,7 @@ import {
   Http2ServerRequest,
   IncomingHttpHeaders as Http2IncomingHttpHeaders,
 } from "http2";
-import { renderPage } from "vite-plugin-ssr/server";
+import { renderPage } from "vike/server";
 import { AugmentMe } from "@alignable/bifrost";
 
 type RenderedPageContext = Awaited<
@@ -60,7 +60,7 @@ interface ViteProxyPluginOptions {
   ) => Http2IncomingHttpHeaders | IncomingHttpHeaders;
 }
 /**
- * Fastify plugin that wraps @fasitfy/http-proxy to proxy Rails/Turbolinks server into a Vite-Plugin-SSR site.
+ * Fastify plugin that wraps @fasitfy/http-proxy to proxy Rails/Turbolinks server into a vike site.
  */
 export const viteProxyPlugin: FastifyPluginAsync<
   ViteProxyPluginOptions
@@ -113,10 +113,12 @@ export const viteProxyPlugin: FastifyPluginAsync<
           ...(buildPageContextInit ? await buildPageContextInit(req) : {}),
         };
 
+        const start = performance.now();
         const pageContext = await renderPage<
           { _pageId: string },
           typeof pageContextInit
         >(pageContextInit);
+        // console.log("renderPage", performance.now() - start);
 
         const proxy = pageContext._pageId === proxyPageId;
         const noRouteMatched =

--- a/bifrost-fastify/index.ts
+++ b/bifrost-fastify/index.ts
@@ -113,12 +113,10 @@ export const viteProxyPlugin: FastifyPluginAsync<
           ...(buildPageContextInit ? await buildPageContextInit(req) : {}),
         };
 
-        const start = performance.now();
         const pageContext = await renderPage<
           { _pageId: string },
           typeof pageContextInit
         >(pageContextInit);
-        // console.log("renderPage", performance.now() - start);
 
         const proxy = pageContext._pageId === proxyPageId;
         const noRouteMatched =

--- a/bifrost-fastify/package.json
+++ b/bifrost-fastify/package.json
@@ -20,7 +20,7 @@
   "peerDependencies": {
     "@alignable/bifrost": "0.0.27",
     "fastify": "^4.9.2",
-    "vite-plugin-ssr": "0.4.138"
+    "vike": "0.4.143"
   },
   "devDependencies": {
     "@types/connect": "^3.4.35",

--- a/bifrost-fastify/package.json
+++ b/bifrost-fastify/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@alignable/bifrost-fastify",
   "repository": "https://github.com/Alignable/bifrost.git",
-  "version": "0.0.27",
+  "version": "0.0.28",
   "type": "module",
   "main": "./dist/index.js",
   "types": "./dist/index.d.ts",
@@ -18,7 +18,7 @@
     "vite": "^4.0.3"
   },
   "peerDependencies": {
-    "@alignable/bifrost": "0.0.27",
+    "@alignable/bifrost": "0.0.28",
     "fastify": "^4.9.2",
     "vike": "0.4.143"
   },

--- a/bifrost/index.ts
+++ b/bifrost/index.ts
@@ -1,4 +1,4 @@
-import { PageContextBuiltIn } from "vite-plugin-ssr/types";
+import { PageContextBuiltIn } from "vike/types";
 import { AugmentMe, PageContextNoProxy } from "./types/internal.js";
 
 export type {
@@ -10,7 +10,10 @@ export type {
   AugmentMe,
   PageContext,
 } from "./types/internal";
-export { usePageContext, PageContextProvider } from "./renderer/usePageContext.js";
+export {
+  usePageContext,
+  PageContextProvider,
+} from "./renderer/usePageContext.js";
 
 type OptionalPromise<T> = Promise<T> | T;
 export type OnBeforeRender = (

--- a/bifrost/lib/turbolinks/index.ts
+++ b/bifrost/lib/turbolinks/index.ts
@@ -36,7 +36,7 @@ export const Turbolinks = {
       (window.Turbolinks.controller.adapter as any).controller = controller;
       controller.adapter = window.Turbolinks.controller.adapter;
     }
-    // Tells vite-plugin-ssr not to do link interception
+    // Tells vike not to do link interception
     (window as any)._disableAutomaticLinkInterception = true;
     window.Turbolinks = Turbolinks;
     controller.start();

--- a/bifrost/lib/turbolinks/visit.ts
+++ b/bifrost/lib/turbolinks/visit.ts
@@ -1,4 +1,4 @@
-import { navigate } from "vite-plugin-ssr/client/router";
+import { navigate } from "vike/client/router";
 import { Adapter } from "./adapter";
 import { Controller } from "./controller.js";
 import { Location } from "./location";

--- a/bifrost/package.json
+++ b/bifrost/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@alignable/bifrost",
   "repository": "https://github.com/Alignable/bifrost.git",
-  "version": "0.0.27",
+  "version": "0.0.28",
   "type": "module",
   "types": "./dist/index.d.ts",
   "exports": {

--- a/bifrost/package.json
+++ b/bifrost/package.json
@@ -83,14 +83,14 @@
     "react-dom": "^18.x.x",
     "tough-cookie": "^4.1.2",
     "uuid": "^9.0.0",
-    "vite-plugin-ssr": "0.4.138"
+    "vike": "0.4.143"
   },
   "peerDependencies": {
     "jsdom": "^22.1.0",
     "react": "^18.x.x",
     "react-dom": "^18.x.x",
     "typescript": ">=4.7",
-    "vite-plugin-ssr": "0.4.138"
+    "vike": "0.4.143"
   },
   "devDependencies": {
     "@types/jsdom": "^21.1.2",

--- a/bifrost/proxy/pages/+config.ts
+++ b/bifrost/proxy/pages/+config.ts
@@ -1,4 +1,4 @@
-import { type Config } from "vite-plugin-ssr/types";
+import { type Config } from "vike/types";
 
 export default {
   route: "/*",

--- a/bifrost/proxy/pages/onRenderHtml.tsx
+++ b/bifrost/proxy/pages/onRenderHtml.tsx
@@ -1,6 +1,6 @@
 import React from "react";
 import ReactDOMServer from "react-dom/server";
-import { dangerouslySkipEscape, escapeInject } from "vite-plugin-ssr/server";
+import { dangerouslySkipEscape, escapeInject } from "vike/server";
 import { PageContextProxyServer } from "../../types/internal.js";
 import { PageShell } from "../../lib/PageShell.js";
 import jsdom from "jsdom";

--- a/bifrost/proxy/pages/restorationVisit/+config.ts
+++ b/bifrost/proxy/pages/restorationVisit/+config.ts
@@ -1,4 +1,4 @@
-import { Config } from "vite-plugin-ssr/types";
+import { Config } from "vike/types";
 
 export default {
   route: "import:@alignable/bifrost/proxy/pages/restorationVisit/route",

--- a/bifrost/renderer/+config.ts
+++ b/bifrost/renderer/+config.ts
@@ -1,4 +1,4 @@
-import { type Config } from "vite-plugin-ssr/types";
+import { type Config } from "vike/types";
 
 const passToClient = [
   "layoutProps",

--- a/bifrost/renderer/onRenderHtml.tsx
+++ b/bifrost/renderer/onRenderHtml.tsx
@@ -1,7 +1,7 @@
 import ReactDOMServer from "react-dom/server";
 import React from "react";
 import { PageShell } from "../lib/PageShell.js";
-import { escapeInject, dangerouslySkipEscape } from "vite-plugin-ssr/server";
+import { escapeInject, dangerouslySkipEscape } from "vike/server";
 import { PageContextNoProxyServer } from "../types/internal.js";
 import { documentPropsToReact } from "./utils/buildHead.js";
 import { getPageContextOrConfig } from "./getConfigOrPageContext.js";
@@ -69,7 +69,7 @@ export default async function onRenderHtml(
   return {
     documentHtml,
     pageContext: {
-      // We can add some `pageContext` here, which is useful if we want to do page redirection https://vite-plugin-ssr.com/page-redirection
+      // We can add some `pageContext` here, which is useful if we want to do page redirection https://vike.com/page-redirection
     },
   };
 }

--- a/bifrost/renderer/usePageContext.tsx
+++ b/bifrost/renderer/usePageContext.tsx
@@ -1,25 +1,34 @@
 // `usePageContext` allows us to access `pageContext` in any React component.
-// See https://vite-plugin-ssr.com/pageContext-anywhere
+// See https://vike.com/pageContext-anywhere
 
-import React, { useContext } from 'react'
+import React, { useContext } from "react";
 import { PageContext } from "../types/internal.js";
-import { getGlobalObject } from './utils/getGlobalObject.js';
+import { getGlobalObject } from "./utils/getGlobalObject.js";
 
-export { PageContextProvider }
-export { usePageContext }
+export { PageContextProvider };
+export { usePageContext };
 
-const { Context } = getGlobalObject('PageContextProvider.ts', {
-  Context: React.createContext<PageContext>(undefined as never)
-})
+const { Context } = getGlobalObject("PageContextProvider.ts", {
+  Context: React.createContext<PageContext>(undefined as never),
+});
 
-function PageContextProvider({ pageContext, children }: { pageContext: PageContext; children: React.ReactNode }) {
-  if (!pageContext) throw new Error('Argument pageContext missing')
-  return <Context.Provider value={pageContext}>{children}</Context.Provider>
+function PageContextProvider({
+  pageContext,
+  children,
+}: {
+  pageContext: PageContext;
+  children: React.ReactNode;
+}) {
+  if (!pageContext) throw new Error("Argument pageContext missing");
+  return <Context.Provider value={pageContext}>{children}</Context.Provider>;
 }
 
 /** Access the pageContext from any React component */
 function usePageContext() {
-  const pageContext = useContext(Context)
-  if (!pageContext) throw new Error('<PageContextProvider> is needed for being able to use usePageContext()')
-  return pageContext
+  const pageContext = useContext(Context);
+  if (!pageContext)
+    throw new Error(
+      "<PageContextProvider> is needed for being able to use usePageContext()"
+    );
+  return pageContext;
 }

--- a/bifrost/types/internal.ts
+++ b/bifrost/types/internal.ts
@@ -3,7 +3,7 @@ import {
   Config,
   PageContextBuiltIn,
   PageContextBuiltInClientWithClientRouting as PageContextBuiltInClient,
-} from "vite-plugin-ssr/types";
+} from "vike/types";
 import InternalProxyConfig from "../proxy/pages/+config.js";
 import InternalNoProxyConfig from "../renderer/+config.js";
 import { type Snapshot } from "../lib/turbolinks/controller.js";

--- a/package-lock.json
+++ b/package-lock.json
@@ -24,7 +24,7 @@
         "react-dom": "^18.x.x",
         "tough-cookie": "^4.1.2",
         "uuid": "^9.0.0",
-        "vite-plugin-ssr": "0.4.138"
+        "vike": "0.4.143"
       },
       "devDependencies": {
         "@types/jsdom": "^21.1.2",
@@ -42,7 +42,7 @@
         "react": "^18.x.x",
         "react-dom": "^18.x.x",
         "typescript": ">=4.7",
-        "vite-plugin-ssr": "0.4.138"
+        "vike": "0.4.143"
       }
     },
     "bifrost-fastify": {
@@ -75,7 +75,7 @@
       "peerDependencies": {
         "@alignable/bifrost": "0.0.27",
         "fastify": "^4.9.2",
-        "vite-plugin-ssr": "0.4.138"
+        "vike": "0.4.143"
       }
     },
     "bifrost/node_modules/@esbuild/darwin-arm64": {
@@ -694,6 +694,7 @@
       "cpu": [
         "arm64"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2419,6 +2420,7 @@
     },
     "node_modules/esbuild": {
       "version": "0.17.18",
+      "dev": true,
       "hasInstallScript": true,
       "license": "MIT",
       "bin": {
@@ -2459,6 +2461,7 @@
       "cpu": [
         "arm"
       ],
+      "dev": true,
       "optional": true,
       "os": [
         "android"
@@ -2474,6 +2477,7 @@
       "cpu": [
         "arm64"
       ],
+      "dev": true,
       "optional": true,
       "os": [
         "android"
@@ -2489,6 +2493,7 @@
       "cpu": [
         "x64"
       ],
+      "dev": true,
       "optional": true,
       "os": [
         "android"
@@ -2504,6 +2509,7 @@
       "cpu": [
         "x64"
       ],
+      "dev": true,
       "optional": true,
       "os": [
         "darwin"
@@ -2519,6 +2525,7 @@
       "cpu": [
         "arm64"
       ],
+      "dev": true,
       "optional": true,
       "os": [
         "freebsd"
@@ -2534,6 +2541,7 @@
       "cpu": [
         "x64"
       ],
+      "dev": true,
       "optional": true,
       "os": [
         "freebsd"
@@ -2549,6 +2557,7 @@
       "cpu": [
         "arm"
       ],
+      "dev": true,
       "optional": true,
       "os": [
         "linux"
@@ -2564,6 +2573,7 @@
       "cpu": [
         "arm64"
       ],
+      "dev": true,
       "optional": true,
       "os": [
         "linux"
@@ -2579,6 +2589,7 @@
       "cpu": [
         "ia32"
       ],
+      "dev": true,
       "optional": true,
       "os": [
         "linux"
@@ -2594,6 +2605,7 @@
       "cpu": [
         "loong64"
       ],
+      "dev": true,
       "optional": true,
       "os": [
         "linux"
@@ -2609,6 +2621,7 @@
       "cpu": [
         "mips64el"
       ],
+      "dev": true,
       "optional": true,
       "os": [
         "linux"
@@ -2624,6 +2637,7 @@
       "cpu": [
         "ppc64"
       ],
+      "dev": true,
       "optional": true,
       "os": [
         "linux"
@@ -2639,6 +2653,7 @@
       "cpu": [
         "riscv64"
       ],
+      "dev": true,
       "optional": true,
       "os": [
         "linux"
@@ -2654,6 +2669,7 @@
       "cpu": [
         "s390x"
       ],
+      "dev": true,
       "optional": true,
       "os": [
         "linux"
@@ -2669,6 +2685,7 @@
       "cpu": [
         "x64"
       ],
+      "dev": true,
       "optional": true,
       "os": [
         "linux"
@@ -2684,6 +2701,7 @@
       "cpu": [
         "x64"
       ],
+      "dev": true,
       "optional": true,
       "os": [
         "netbsd"
@@ -2699,6 +2717,7 @@
       "cpu": [
         "x64"
       ],
+      "dev": true,
       "optional": true,
       "os": [
         "openbsd"
@@ -2714,6 +2733,7 @@
       "cpu": [
         "x64"
       ],
+      "dev": true,
       "optional": true,
       "os": [
         "sunos"
@@ -2729,6 +2749,7 @@
       "cpu": [
         "arm64"
       ],
+      "dev": true,
       "optional": true,
       "os": [
         "win32"
@@ -2744,6 +2765,7 @@
       "cpu": [
         "ia32"
       ],
+      "dev": true,
       "optional": true,
       "os": [
         "win32"
@@ -2759,6 +2781,7 @@
       "cpu": [
         "x64"
       ],
+      "dev": true,
       "optional": true,
       "os": [
         "win32"
@@ -3014,8 +3037,9 @@
       "license": "MIT"
     },
     "node_modules/fastify/node_modules/semver": {
-      "version": "7.5.0",
-      "license": "ISC",
+      "version": "7.5.4",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-7.5.4.tgz",
+      "integrity": "sha512-1bCSESV6Pv+i21Hvpxp3Dx+pSD8lIPt8uVjRrxAUt/nbswYc+tK6Y2btiULjd4+fnq15PX+nqQDC7Oft7WkwcA==",
       "dependencies": {
         "lru-cache": "^6.0.0"
       },
@@ -4108,8 +4132,9 @@
       }
     },
     "node_modules/nodemon/node_modules/semver": {
-      "version": "5.7.1",
-      "license": "ISC",
+      "version": "5.7.2",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-5.7.2.tgz",
+      "integrity": "sha512-cBznnQ9KjJqU67B52RMC65CMarK2600WFnbkcaiwWq3xy/5haFJlshgnpjovMVJ+Hff49d8GEn0b87C5pDQ10g==",
       "bin": {
         "semver": "bin/semver"
       }
@@ -4385,7 +4410,9 @@
       }
     },
     "node_modules/postcss": {
-      "version": "8.4.23",
+      "version": "8.4.31",
+      "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.4.31.tgz",
+      "integrity": "sha512-PS08Iboia9mts/2ygV3eLpY5ghnUcfLV/EXTOW1E2qYxJKGGBUtNjN76FYHnMs36RmARn41bC0AZmn+rR0OVpQ==",
       "funding": [
         {
           "type": "opencollective",
@@ -4400,7 +4427,6 @@
           "url": "https://github.com/sponsors/ai"
         }
       ],
-      "license": "MIT",
       "dependencies": {
         "nanoid": "^3.3.6",
         "picocolors": "^1.0.0",
@@ -4877,8 +4903,9 @@
       "license": "MIT"
     },
     "node_modules/rollup": {
-      "version": "3.20.7",
-      "license": "MIT",
+      "version": "3.29.4",
+      "resolved": "https://registry.npmjs.org/rollup/-/rollup-3.29.4.tgz",
+      "integrity": "sha512-oWzmBZwvYrU0iJHtDmhsm662rC15FRXmcjCk1xD771dFDx5jJ02ufAQQTn0etB2emNk4J9EZg/yWKpsn9BWGRw==",
       "bin": {
         "rollup": "dist/bin/rollup"
       },
@@ -4997,9 +5024,10 @@
       "integrity": "sha512-mEugaLK+YfkijB4fx0e6kImuJdCIt2LxCRcbEYPqRGCs4F2ogyfZU5IAZRdjCP8JPq2AtdNoC/Dux63d9Kiryg=="
     },
     "node_modules/semver": {
-      "version": "6.3.0",
+      "version": "6.3.1",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-6.3.1.tgz",
+      "integrity": "sha512-BR7VvDCVHO+q2xBEWskxS6DJE1qRnb7DxzUrogb71CWoSficBxYsiAGd+Kl0mmq/MprG9yArRkyrQxTO6XjMzA==",
       "dev": true,
-      "license": "ISC",
       "bin": {
         "semver": "bin/semver.js"
       }
@@ -5497,9 +5525,9 @@
       }
     },
     "node_modules/tough-cookie": {
-      "version": "4.1.2",
-      "resolved": "https://registry.npmjs.org/tough-cookie/-/tough-cookie-4.1.2.tgz",
-      "integrity": "sha512-G9fqXWoYFZgTc2z8Q5zaHy/vJMjm+WV0AkAeHxVCQiEB1b+dGvWzFW6QV07cY5jQ5gRkeid2qIkzkxUnmoQZUQ==",
+      "version": "4.1.3",
+      "resolved": "https://registry.npmjs.org/tough-cookie/-/tough-cookie-4.1.3.tgz",
+      "integrity": "sha512-aX/y5pVRkfRnfmuX+OdbSdXvPe6ieKX/G2s7e98f4poJHnqH3281gDPm/metm6E/WRamfx7WC4HUqkWHfQHprw==",
       "dependencies": {
         "psl": "^1.1.33",
         "punycode": "^2.1.1",
@@ -5622,21 +5650,6 @@
         "typescript": {
           "optional": true
         }
-      }
-    },
-    "node_modules/tsup/node_modules/rollup": {
-      "version": "3.21.3",
-      "dev": true,
-      "license": "MIT",
-      "bin": {
-        "rollup": "dist/bin/rollup"
-      },
-      "engines": {
-        "node": ">=14.18.0",
-        "npm": ">=8.0.0"
-      },
-      "optionalDependencies": {
-        "fsevents": "~2.3.2"
       }
     },
     "node_modules/tunnel-agent": {
@@ -5809,55 +5822,9 @@
       "resolved": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.2.tgz",
       "integrity": "sha512-3lqz5YjWTYnW6dlDa5TLaTCcShfar1e40rmcJVwCBJC6mWlFuj0eCHIElmG1g5kyuJ/GD+8Wn4FFCcz4gJPfaQ=="
     },
-    "node_modules/vite": {
-      "version": "4.3.1",
-      "license": "MIT",
-      "dependencies": {
-        "esbuild": "^0.17.5",
-        "postcss": "^8.4.21",
-        "rollup": "^3.20.2"
-      },
-      "bin": {
-        "vite": "bin/vite.js"
-      },
-      "engines": {
-        "node": "^14.18.0 || >=16.0.0"
-      },
-      "optionalDependencies": {
-        "fsevents": "~2.3.2"
-      },
-      "peerDependencies": {
-        "@types/node": ">= 14",
-        "less": "*",
-        "sass": "*",
-        "stylus": "*",
-        "sugarss": "*",
-        "terser": "^5.4.0"
-      },
-      "peerDependenciesMeta": {
-        "@types/node": {
-          "optional": true
-        },
-        "less": {
-          "optional": true
-        },
-        "sass": {
-          "optional": true
-        },
-        "stylus": {
-          "optional": true
-        },
-        "sugarss": {
-          "optional": true
-        },
-        "terser": {
-          "optional": true
-        }
-      }
-    },
-    "node_modules/vite-plugin-ssr": {
-      "version": "0.4.138",
-      "resolved": "https://registry.npmjs.org/vite-plugin-ssr/-/vite-plugin-ssr-0.4.138.tgz",
+    "node_modules/vike": {
+      "version": "0.4.143",
+      "resolved": "https://registry.npmjs.org/vike/-/vike-0.4.143.tgz",
       "integrity": "sha512-ISaaB9sfKYo0i3bT9hP8ENgJdTFeMk6K68tToX0o/0B8ilklYol5Rekg6JSuMoUhZxPqEjSrudgJegSyhiwNoQ==",
       "dependencies": {
         "@brillout/import": "0.2.3",
@@ -5874,7 +5841,7 @@
         "source-map-support": "^0.5.21"
       },
       "bin": {
-        "vite-plugin-ssr": "node/cli/bin-entry.js"
+        "vike": "node/cli/bin-entry.js"
       },
       "engines": {
         "node": ">=16.0.0"
@@ -5889,7 +5856,7 @@
         }
       }
     },
-    "node_modules/vite-plugin-ssr/node_modules/@esbuild/android-arm": {
+    "node_modules/vike/node_modules/@esbuild/android-arm": {
       "version": "0.17.19",
       "resolved": "https://registry.npmjs.org/@esbuild/android-arm/-/android-arm-0.17.19.tgz",
       "integrity": "sha512-rIKddzqhmav7MSmoFCmDIb6e2W57geRsM94gV2l38fzhXMwq7hZoClug9USI2pFRGL06f4IOPHHpFNOkWieR8A==",
@@ -5904,7 +5871,7 @@
         "node": ">=12"
       }
     },
-    "node_modules/vite-plugin-ssr/node_modules/@esbuild/android-arm64": {
+    "node_modules/vike/node_modules/@esbuild/android-arm64": {
       "version": "0.17.19",
       "resolved": "https://registry.npmjs.org/@esbuild/android-arm64/-/android-arm64-0.17.19.tgz",
       "integrity": "sha512-KBMWvEZooR7+kzY0BtbTQn0OAYY7CsiydT63pVEaPtVYF0hXbUaOyZog37DKxK7NF3XacBJOpYT4adIJh+avxA==",
@@ -5919,7 +5886,7 @@
         "node": ">=12"
       }
     },
-    "node_modules/vite-plugin-ssr/node_modules/@esbuild/android-x64": {
+    "node_modules/vike/node_modules/@esbuild/android-x64": {
       "version": "0.17.19",
       "resolved": "https://registry.npmjs.org/@esbuild/android-x64/-/android-x64-0.17.19.tgz",
       "integrity": "sha512-uUTTc4xGNDT7YSArp/zbtmbhO0uEEK9/ETW29Wk1thYUJBz3IVnvgEiEwEa9IeLyvnpKrWK64Utw2bgUmDveww==",
@@ -5934,7 +5901,7 @@
         "node": ">=12"
       }
     },
-    "node_modules/vite-plugin-ssr/node_modules/@esbuild/darwin-arm64": {
+    "node_modules/vike/node_modules/@esbuild/darwin-arm64": {
       "version": "0.17.19",
       "cpu": [
         "arm64"
@@ -5948,7 +5915,7 @@
         "node": ">=12"
       }
     },
-    "node_modules/vite-plugin-ssr/node_modules/@esbuild/darwin-x64": {
+    "node_modules/vike/node_modules/@esbuild/darwin-x64": {
       "version": "0.17.19",
       "resolved": "https://registry.npmjs.org/@esbuild/darwin-x64/-/darwin-x64-0.17.19.tgz",
       "integrity": "sha512-IJM4JJsLhRYr9xdtLytPLSH9k/oxR3boaUIYiHkAawtwNOXKE8KoU8tMvryogdcT8AU+Bflmh81Xn6Q0vTZbQw==",
@@ -5963,7 +5930,7 @@
         "node": ">=12"
       }
     },
-    "node_modules/vite-plugin-ssr/node_modules/@esbuild/freebsd-arm64": {
+    "node_modules/vike/node_modules/@esbuild/freebsd-arm64": {
       "version": "0.17.19",
       "resolved": "https://registry.npmjs.org/@esbuild/freebsd-arm64/-/freebsd-arm64-0.17.19.tgz",
       "integrity": "sha512-pBwbc7DufluUeGdjSU5Si+P3SoMF5DQ/F/UmTSb8HXO80ZEAJmrykPyzo1IfNbAoaqw48YRpv8shwd1NoI0jcQ==",
@@ -5978,7 +5945,7 @@
         "node": ">=12"
       }
     },
-    "node_modules/vite-plugin-ssr/node_modules/@esbuild/freebsd-x64": {
+    "node_modules/vike/node_modules/@esbuild/freebsd-x64": {
       "version": "0.17.19",
       "resolved": "https://registry.npmjs.org/@esbuild/freebsd-x64/-/freebsd-x64-0.17.19.tgz",
       "integrity": "sha512-4lu+n8Wk0XlajEhbEffdy2xy53dpR06SlzvhGByyg36qJw6Kpfk7cp45DR/62aPH9mtJRmIyrXAS5UWBrJT6TQ==",
@@ -5993,7 +5960,7 @@
         "node": ">=12"
       }
     },
-    "node_modules/vite-plugin-ssr/node_modules/@esbuild/linux-arm": {
+    "node_modules/vike/node_modules/@esbuild/linux-arm": {
       "version": "0.17.19",
       "resolved": "https://registry.npmjs.org/@esbuild/linux-arm/-/linux-arm-0.17.19.tgz",
       "integrity": "sha512-cdmT3KxjlOQ/gZ2cjfrQOtmhG4HJs6hhvm3mWSRDPtZ/lP5oe8FWceS10JaSJC13GBd4eH/haHnqf7hhGNLerA==",
@@ -6008,7 +5975,7 @@
         "node": ">=12"
       }
     },
-    "node_modules/vite-plugin-ssr/node_modules/@esbuild/linux-arm64": {
+    "node_modules/vike/node_modules/@esbuild/linux-arm64": {
       "version": "0.17.19",
       "resolved": "https://registry.npmjs.org/@esbuild/linux-arm64/-/linux-arm64-0.17.19.tgz",
       "integrity": "sha512-ct1Tg3WGwd3P+oZYqic+YZF4snNl2bsnMKRkb3ozHmnM0dGWuxcPTTntAF6bOP0Sp4x0PjSF+4uHQ1xvxfRKqg==",
@@ -6023,7 +5990,7 @@
         "node": ">=12"
       }
     },
-    "node_modules/vite-plugin-ssr/node_modules/@esbuild/linux-ia32": {
+    "node_modules/vike/node_modules/@esbuild/linux-ia32": {
       "version": "0.17.19",
       "resolved": "https://registry.npmjs.org/@esbuild/linux-ia32/-/linux-ia32-0.17.19.tgz",
       "integrity": "sha512-w4IRhSy1VbsNxHRQpeGCHEmibqdTUx61Vc38APcsRbuVgK0OPEnQ0YD39Brymn96mOx48Y2laBQGqgZ0j9w6SQ==",
@@ -6038,7 +6005,7 @@
         "node": ">=12"
       }
     },
-    "node_modules/vite-plugin-ssr/node_modules/@esbuild/linux-loong64": {
+    "node_modules/vike/node_modules/@esbuild/linux-loong64": {
       "version": "0.17.19",
       "resolved": "https://registry.npmjs.org/@esbuild/linux-loong64/-/linux-loong64-0.17.19.tgz",
       "integrity": "sha512-2iAngUbBPMq439a+z//gE+9WBldoMp1s5GWsUSgqHLzLJ9WoZLZhpwWuym0u0u/4XmZ3gpHmzV84PonE+9IIdQ==",
@@ -6053,7 +6020,7 @@
         "node": ">=12"
       }
     },
-    "node_modules/vite-plugin-ssr/node_modules/@esbuild/linux-mips64el": {
+    "node_modules/vike/node_modules/@esbuild/linux-mips64el": {
       "version": "0.17.19",
       "resolved": "https://registry.npmjs.org/@esbuild/linux-mips64el/-/linux-mips64el-0.17.19.tgz",
       "integrity": "sha512-LKJltc4LVdMKHsrFe4MGNPp0hqDFA1Wpt3jE1gEyM3nKUvOiO//9PheZZHfYRfYl6AwdTH4aTcXSqBerX0ml4A==",
@@ -6068,7 +6035,7 @@
         "node": ">=12"
       }
     },
-    "node_modules/vite-plugin-ssr/node_modules/@esbuild/linux-ppc64": {
+    "node_modules/vike/node_modules/@esbuild/linux-ppc64": {
       "version": "0.17.19",
       "resolved": "https://registry.npmjs.org/@esbuild/linux-ppc64/-/linux-ppc64-0.17.19.tgz",
       "integrity": "sha512-/c/DGybs95WXNS8y3Ti/ytqETiW7EU44MEKuCAcpPto3YjQbyK3IQVKfF6nbghD7EcLUGl0NbiL5Rt5DMhn5tg==",
@@ -6083,7 +6050,7 @@
         "node": ">=12"
       }
     },
-    "node_modules/vite-plugin-ssr/node_modules/@esbuild/linux-riscv64": {
+    "node_modules/vike/node_modules/@esbuild/linux-riscv64": {
       "version": "0.17.19",
       "resolved": "https://registry.npmjs.org/@esbuild/linux-riscv64/-/linux-riscv64-0.17.19.tgz",
       "integrity": "sha512-FC3nUAWhvFoutlhAkgHf8f5HwFWUL6bYdvLc/TTuxKlvLi3+pPzdZiFKSWz/PF30TB1K19SuCxDTI5KcqASJqA==",
@@ -6098,7 +6065,7 @@
         "node": ">=12"
       }
     },
-    "node_modules/vite-plugin-ssr/node_modules/@esbuild/linux-s390x": {
+    "node_modules/vike/node_modules/@esbuild/linux-s390x": {
       "version": "0.17.19",
       "resolved": "https://registry.npmjs.org/@esbuild/linux-s390x/-/linux-s390x-0.17.19.tgz",
       "integrity": "sha512-IbFsFbxMWLuKEbH+7sTkKzL6NJmG2vRyy6K7JJo55w+8xDk7RElYn6xvXtDW8HCfoKBFK69f3pgBJSUSQPr+4Q==",
@@ -6113,7 +6080,7 @@
         "node": ">=12"
       }
     },
-    "node_modules/vite-plugin-ssr/node_modules/@esbuild/linux-x64": {
+    "node_modules/vike/node_modules/@esbuild/linux-x64": {
       "version": "0.17.19",
       "resolved": "https://registry.npmjs.org/@esbuild/linux-x64/-/linux-x64-0.17.19.tgz",
       "integrity": "sha512-68ngA9lg2H6zkZcyp22tsVt38mlhWde8l3eJLWkyLrp4HwMUr3c1s/M2t7+kHIhvMjglIBrFpncX1SzMckomGw==",
@@ -6128,7 +6095,7 @@
         "node": ">=12"
       }
     },
-    "node_modules/vite-plugin-ssr/node_modules/@esbuild/netbsd-x64": {
+    "node_modules/vike/node_modules/@esbuild/netbsd-x64": {
       "version": "0.17.19",
       "resolved": "https://registry.npmjs.org/@esbuild/netbsd-x64/-/netbsd-x64-0.17.19.tgz",
       "integrity": "sha512-CwFq42rXCR8TYIjIfpXCbRX0rp1jo6cPIUPSaWwzbVI4aOfX96OXY8M6KNmtPcg7QjYeDmN+DD0Wp3LaBOLf4Q==",
@@ -6143,7 +6110,7 @@
         "node": ">=12"
       }
     },
-    "node_modules/vite-plugin-ssr/node_modules/@esbuild/openbsd-x64": {
+    "node_modules/vike/node_modules/@esbuild/openbsd-x64": {
       "version": "0.17.19",
       "resolved": "https://registry.npmjs.org/@esbuild/openbsd-x64/-/openbsd-x64-0.17.19.tgz",
       "integrity": "sha512-cnq5brJYrSZ2CF6c35eCmviIN3k3RczmHz8eYaVlNasVqsNY+JKohZU5MKmaOI+KkllCdzOKKdPs762VCPC20g==",
@@ -6158,7 +6125,7 @@
         "node": ">=12"
       }
     },
-    "node_modules/vite-plugin-ssr/node_modules/@esbuild/sunos-x64": {
+    "node_modules/vike/node_modules/@esbuild/sunos-x64": {
       "version": "0.17.19",
       "resolved": "https://registry.npmjs.org/@esbuild/sunos-x64/-/sunos-x64-0.17.19.tgz",
       "integrity": "sha512-vCRT7yP3zX+bKWFeP/zdS6SqdWB8OIpaRq/mbXQxTGHnIxspRtigpkUcDMlSCOejlHowLqII7K2JKevwyRP2rg==",
@@ -6173,7 +6140,7 @@
         "node": ">=12"
       }
     },
-    "node_modules/vite-plugin-ssr/node_modules/@esbuild/win32-arm64": {
+    "node_modules/vike/node_modules/@esbuild/win32-arm64": {
       "version": "0.17.19",
       "resolved": "https://registry.npmjs.org/@esbuild/win32-arm64/-/win32-arm64-0.17.19.tgz",
       "integrity": "sha512-yYx+8jwowUstVdorcMdNlzklLYhPxjniHWFKgRqH7IFlUEa0Umu3KuYplf1HUZZ422e3NU9F4LGb+4O0Kdcaag==",
@@ -6188,7 +6155,7 @@
         "node": ">=12"
       }
     },
-    "node_modules/vite-plugin-ssr/node_modules/@esbuild/win32-ia32": {
+    "node_modules/vike/node_modules/@esbuild/win32-ia32": {
       "version": "0.17.19",
       "resolved": "https://registry.npmjs.org/@esbuild/win32-ia32/-/win32-ia32-0.17.19.tgz",
       "integrity": "sha512-eggDKanJszUtCdlVs0RB+h35wNlb5v4TWEkq4vZcmVt5u/HiDZrTXe2bWFQUez3RgNHwx/x4sk5++4NSSicKkw==",
@@ -6203,7 +6170,7 @@
         "node": ">=12"
       }
     },
-    "node_modules/vite-plugin-ssr/node_modules/@esbuild/win32-x64": {
+    "node_modules/vike/node_modules/@esbuild/win32-x64": {
       "version": "0.17.19",
       "resolved": "https://registry.npmjs.org/@esbuild/win32-x64/-/win32-x64-0.17.19.tgz",
       "integrity": "sha512-lAhycmKnVOuRYNtRtatQR1LPQf2oYCkRGkSFnseDAKPl8lu5SOsK/e1sXe5a0Pc5kHIHe6P2I/ilntNv2xf3cA==",
@@ -6218,7 +6185,7 @@
         "node": ">=12"
       }
     },
-    "node_modules/vite-plugin-ssr/node_modules/esbuild": {
+    "node_modules/vike/node_modules/esbuild": {
       "version": "0.17.19",
       "hasInstallScript": true,
       "license": "MIT",
@@ -6251,6 +6218,426 @@
         "@esbuild/win32-arm64": "0.17.19",
         "@esbuild/win32-ia32": "0.17.19",
         "@esbuild/win32-x64": "0.17.19"
+      }
+    },
+    "node_modules/vite": {
+      "version": "4.4.11",
+      "resolved": "https://registry.npmjs.org/vite/-/vite-4.4.11.tgz",
+      "integrity": "sha512-ksNZJlkcU9b0lBwAGZGGaZHCMqHsc8OpgtoYhsQ4/I2v5cnpmmmqe5pM4nv/4Hn6G/2GhTdj0DhZh2e+Er1q5A==",
+      "dependencies": {
+        "esbuild": "^0.18.10",
+        "postcss": "^8.4.27",
+        "rollup": "^3.27.1"
+      },
+      "bin": {
+        "vite": "bin/vite.js"
+      },
+      "engines": {
+        "node": "^14.18.0 || >=16.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/vitejs/vite?sponsor=1"
+      },
+      "optionalDependencies": {
+        "fsevents": "~2.3.2"
+      },
+      "peerDependencies": {
+        "@types/node": ">= 14",
+        "less": "*",
+        "lightningcss": "^1.21.0",
+        "sass": "*",
+        "stylus": "*",
+        "sugarss": "*",
+        "terser": "^5.4.0"
+      },
+      "peerDependenciesMeta": {
+        "@types/node": {
+          "optional": true
+        },
+        "less": {
+          "optional": true
+        },
+        "lightningcss": {
+          "optional": true
+        },
+        "sass": {
+          "optional": true
+        },
+        "stylus": {
+          "optional": true
+        },
+        "sugarss": {
+          "optional": true
+        },
+        "terser": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/vite/node_modules/@esbuild/android-arm": {
+      "version": "0.18.20",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-arm/-/android-arm-0.18.20.tgz",
+      "integrity": "sha512-fyi7TDI/ijKKNZTUJAQqiG5T7YjJXgnzkURqmGj13C6dCqckZBLdl4h7bkhHt/t0WP+zO9/zwroDvANaOqO5Sw==",
+      "cpu": [
+        "arm"
+      ],
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/vite/node_modules/@esbuild/android-arm64": {
+      "version": "0.18.20",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-arm64/-/android-arm64-0.18.20.tgz",
+      "integrity": "sha512-Nz4rJcchGDtENV0eMKUNa6L12zz2zBDXuhj/Vjh18zGqB44Bi7MBMSXjgunJgjRhCmKOjnPuZp4Mb6OKqtMHLQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/vite/node_modules/@esbuild/android-x64": {
+      "version": "0.18.20",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-x64/-/android-x64-0.18.20.tgz",
+      "integrity": "sha512-8GDdlePJA8D6zlZYJV/jnrRAi6rOiNaCC/JclcXpB+KIuvfBN4owLtgzY2bsxnx666XjJx2kDPUmnTtR8qKQUg==",
+      "cpu": [
+        "x64"
+      ],
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/vite/node_modules/@esbuild/darwin-arm64": {
+      "version": "0.18.20",
+      "resolved": "https://registry.npmjs.org/@esbuild/darwin-arm64/-/darwin-arm64-0.18.20.tgz",
+      "integrity": "sha512-bxRHW5kHU38zS2lPTPOyuyTm+S+eobPUnTNkdJEfAddYgEcll4xkT8DB9d2008DtTbl7uJag2HuE5NZAZgnNEA==",
+      "cpu": [
+        "arm64"
+      ],
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/vite/node_modules/@esbuild/darwin-x64": {
+      "version": "0.18.20",
+      "resolved": "https://registry.npmjs.org/@esbuild/darwin-x64/-/darwin-x64-0.18.20.tgz",
+      "integrity": "sha512-pc5gxlMDxzm513qPGbCbDukOdsGtKhfxD1zJKXjCCcU7ju50O7MeAZ8c4krSJcOIJGFR+qx21yMMVYwiQvyTyQ==",
+      "cpu": [
+        "x64"
+      ],
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/vite/node_modules/@esbuild/freebsd-arm64": {
+      "version": "0.18.20",
+      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-arm64/-/freebsd-arm64-0.18.20.tgz",
+      "integrity": "sha512-yqDQHy4QHevpMAaxhhIwYPMv1NECwOvIpGCZkECn8w2WFHXjEwrBn3CeNIYsibZ/iZEUemj++M26W3cNR5h+Tw==",
+      "cpu": [
+        "arm64"
+      ],
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/vite/node_modules/@esbuild/freebsd-x64": {
+      "version": "0.18.20",
+      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-x64/-/freebsd-x64-0.18.20.tgz",
+      "integrity": "sha512-tgWRPPuQsd3RmBZwarGVHZQvtzfEBOreNuxEMKFcd5DaDn2PbBxfwLcj4+aenoh7ctXcbXmOQIn8HI6mCSw5MQ==",
+      "cpu": [
+        "x64"
+      ],
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/vite/node_modules/@esbuild/linux-arm": {
+      "version": "0.18.20",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm/-/linux-arm-0.18.20.tgz",
+      "integrity": "sha512-/5bHkMWnq1EgKr1V+Ybz3s1hWXok7mDFUMQ4cG10AfW3wL02PSZi5kFpYKrptDsgb2WAJIvRcDm+qIvXf/apvg==",
+      "cpu": [
+        "arm"
+      ],
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/vite/node_modules/@esbuild/linux-arm64": {
+      "version": "0.18.20",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm64/-/linux-arm64-0.18.20.tgz",
+      "integrity": "sha512-2YbscF+UL7SQAVIpnWvYwM+3LskyDmPhe31pE7/aoTMFKKzIc9lLbyGUpmmb8a8AixOL61sQ/mFh3jEjHYFvdA==",
+      "cpu": [
+        "arm64"
+      ],
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/vite/node_modules/@esbuild/linux-ia32": {
+      "version": "0.18.20",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-ia32/-/linux-ia32-0.18.20.tgz",
+      "integrity": "sha512-P4etWwq6IsReT0E1KHU40bOnzMHoH73aXp96Fs8TIT6z9Hu8G6+0SHSw9i2isWrD2nbx2qo5yUqACgdfVGx7TA==",
+      "cpu": [
+        "ia32"
+      ],
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/vite/node_modules/@esbuild/linux-loong64": {
+      "version": "0.18.20",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-loong64/-/linux-loong64-0.18.20.tgz",
+      "integrity": "sha512-nXW8nqBTrOpDLPgPY9uV+/1DjxoQ7DoB2N8eocyq8I9XuqJ7BiAMDMf9n1xZM9TgW0J8zrquIb/A7s3BJv7rjg==",
+      "cpu": [
+        "loong64"
+      ],
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/vite/node_modules/@esbuild/linux-mips64el": {
+      "version": "0.18.20",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-mips64el/-/linux-mips64el-0.18.20.tgz",
+      "integrity": "sha512-d5NeaXZcHp8PzYy5VnXV3VSd2D328Zb+9dEq5HE6bw6+N86JVPExrA6O68OPwobntbNJ0pzCpUFZTo3w0GyetQ==",
+      "cpu": [
+        "mips64el"
+      ],
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/vite/node_modules/@esbuild/linux-ppc64": {
+      "version": "0.18.20",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-ppc64/-/linux-ppc64-0.18.20.tgz",
+      "integrity": "sha512-WHPyeScRNcmANnLQkq6AfyXRFr5D6N2sKgkFo2FqguP44Nw2eyDlbTdZwd9GYk98DZG9QItIiTlFLHJHjxP3FA==",
+      "cpu": [
+        "ppc64"
+      ],
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/vite/node_modules/@esbuild/linux-riscv64": {
+      "version": "0.18.20",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-riscv64/-/linux-riscv64-0.18.20.tgz",
+      "integrity": "sha512-WSxo6h5ecI5XH34KC7w5veNnKkju3zBRLEQNY7mv5mtBmrP/MjNBCAlsM2u5hDBlS3NGcTQpoBvRzqBcRtpq1A==",
+      "cpu": [
+        "riscv64"
+      ],
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/vite/node_modules/@esbuild/linux-s390x": {
+      "version": "0.18.20",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-s390x/-/linux-s390x-0.18.20.tgz",
+      "integrity": "sha512-+8231GMs3mAEth6Ja1iK0a1sQ3ohfcpzpRLH8uuc5/KVDFneH6jtAJLFGafpzpMRO6DzJ6AvXKze9LfFMrIHVQ==",
+      "cpu": [
+        "s390x"
+      ],
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/vite/node_modules/@esbuild/linux-x64": {
+      "version": "0.18.20",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-x64/-/linux-x64-0.18.20.tgz",
+      "integrity": "sha512-UYqiqemphJcNsFEskc73jQ7B9jgwjWrSayxawS6UVFZGWrAAtkzjxSqnoclCXxWtfwLdzU+vTpcNYhpn43uP1w==",
+      "cpu": [
+        "x64"
+      ],
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/vite/node_modules/@esbuild/netbsd-x64": {
+      "version": "0.18.20",
+      "resolved": "https://registry.npmjs.org/@esbuild/netbsd-x64/-/netbsd-x64-0.18.20.tgz",
+      "integrity": "sha512-iO1c++VP6xUBUmltHZoMtCUdPlnPGdBom6IrO4gyKPFFVBKioIImVooR5I83nTew5UOYrk3gIJhbZh8X44y06A==",
+      "cpu": [
+        "x64"
+      ],
+      "optional": true,
+      "os": [
+        "netbsd"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/vite/node_modules/@esbuild/openbsd-x64": {
+      "version": "0.18.20",
+      "resolved": "https://registry.npmjs.org/@esbuild/openbsd-x64/-/openbsd-x64-0.18.20.tgz",
+      "integrity": "sha512-e5e4YSsuQfX4cxcygw/UCPIEP6wbIL+se3sxPdCiMbFLBWu0eiZOJ7WoD+ptCLrmjZBK1Wk7I6D/I3NglUGOxg==",
+      "cpu": [
+        "x64"
+      ],
+      "optional": true,
+      "os": [
+        "openbsd"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/vite/node_modules/@esbuild/sunos-x64": {
+      "version": "0.18.20",
+      "resolved": "https://registry.npmjs.org/@esbuild/sunos-x64/-/sunos-x64-0.18.20.tgz",
+      "integrity": "sha512-kDbFRFp0YpTQVVrqUd5FTYmWo45zGaXe0X8E1G/LKFC0v8x0vWrhOWSLITcCn63lmZIxfOMXtCfti/RxN/0wnQ==",
+      "cpu": [
+        "x64"
+      ],
+      "optional": true,
+      "os": [
+        "sunos"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/vite/node_modules/@esbuild/win32-arm64": {
+      "version": "0.18.20",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-arm64/-/win32-arm64-0.18.20.tgz",
+      "integrity": "sha512-ddYFR6ItYgoaq4v4JmQQaAI5s7npztfV4Ag6NrhiaW0RrnOXqBkgwZLofVTlq1daVTQNhtI5oieTvkRPfZrePg==",
+      "cpu": [
+        "arm64"
+      ],
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/vite/node_modules/@esbuild/win32-ia32": {
+      "version": "0.18.20",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-ia32/-/win32-ia32-0.18.20.tgz",
+      "integrity": "sha512-Wv7QBi3ID/rROT08SABTS7eV4hX26sVduqDOTe1MvGMjNd3EjOz4b7zeexIR62GTIEKrfJXKL9LFxTYgkyeu7g==",
+      "cpu": [
+        "ia32"
+      ],
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/vite/node_modules/@esbuild/win32-x64": {
+      "version": "0.18.20",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-x64/-/win32-x64-0.18.20.tgz",
+      "integrity": "sha512-kTdfRcSiDfQca/y9QIkng02avJ+NCaQvrMejlsB3RRv5sE9rRoeBPISaZpKxHELzRxZyLvNts1P27W3wV+8geQ==",
+      "cpu": [
+        "x64"
+      ],
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/vite/node_modules/esbuild": {
+      "version": "0.18.20",
+      "resolved": "https://registry.npmjs.org/esbuild/-/esbuild-0.18.20.tgz",
+      "integrity": "sha512-ceqxoedUrcayh7Y7ZX6NdbbDzGROiyVBgC4PriJThBKSVPWnnFHZAkfI1lJT8QFkOwH4qOS2SJkS4wvpGl8BpA==",
+      "hasInstallScript": true,
+      "bin": {
+        "esbuild": "bin/esbuild"
+      },
+      "engines": {
+        "node": ">=12"
+      },
+      "optionalDependencies": {
+        "@esbuild/android-arm": "0.18.20",
+        "@esbuild/android-arm64": "0.18.20",
+        "@esbuild/android-x64": "0.18.20",
+        "@esbuild/darwin-arm64": "0.18.20",
+        "@esbuild/darwin-x64": "0.18.20",
+        "@esbuild/freebsd-arm64": "0.18.20",
+        "@esbuild/freebsd-x64": "0.18.20",
+        "@esbuild/linux-arm": "0.18.20",
+        "@esbuild/linux-arm64": "0.18.20",
+        "@esbuild/linux-ia32": "0.18.20",
+        "@esbuild/linux-loong64": "0.18.20",
+        "@esbuild/linux-mips64el": "0.18.20",
+        "@esbuild/linux-ppc64": "0.18.20",
+        "@esbuild/linux-riscv64": "0.18.20",
+        "@esbuild/linux-s390x": "0.18.20",
+        "@esbuild/linux-x64": "0.18.20",
+        "@esbuild/netbsd-x64": "0.18.20",
+        "@esbuild/openbsd-x64": "0.18.20",
+        "@esbuild/sunos-x64": "0.18.20",
+        "@esbuild/win32-arm64": "0.18.20",
+        "@esbuild/win32-ia32": "0.18.20",
+        "@esbuild/win32-x64": "0.18.20"
       }
     },
     "node_modules/w3c-xmlserializer": {
@@ -6489,71 +6876,11 @@
         "nodemon": "^2.0.21",
         "ts-node": "^10.9.1",
         "uuid": "^9.0.0",
-        "vite": "^4.3.2",
-        "vite-plugin-ssr": "0.4.138"
+        "vike": "0.4.143",
+        "vite": "^4.3.2"
       },
       "devDependencies": {
         "@types/uuid": "^9.0.1"
-      }
-    },
-    "tests/vite/node_modules/rollup": {
-      "version": "3.21.0",
-      "license": "MIT",
-      "bin": {
-        "rollup": "dist/bin/rollup"
-      },
-      "engines": {
-        "node": ">=14.18.0",
-        "npm": ">=8.0.0"
-      },
-      "optionalDependencies": {
-        "fsevents": "~2.3.2"
-      }
-    },
-    "tests/vite/node_modules/vite": {
-      "version": "4.3.2",
-      "license": "MIT",
-      "dependencies": {
-        "esbuild": "^0.17.5",
-        "postcss": "^8.4.21",
-        "rollup": "^3.21.0"
-      },
-      "bin": {
-        "vite": "bin/vite.js"
-      },
-      "engines": {
-        "node": "^14.18.0 || >=16.0.0"
-      },
-      "optionalDependencies": {
-        "fsevents": "~2.3.2"
-      },
-      "peerDependencies": {
-        "@types/node": ">= 14",
-        "less": "*",
-        "sass": "*",
-        "stylus": "*",
-        "sugarss": "*",
-        "terser": "^5.4.0"
-      },
-      "peerDependenciesMeta": {
-        "@types/node": {
-          "optional": true
-        },
-        "less": {
-          "optional": true
-        },
-        "sass": {
-          "optional": true
-        },
-        "stylus": {
-          "optional": true
-        },
-        "sugarss": {
-          "optional": true
-        },
-        "terser": {
-          "optional": true
-        }
       }
     }
   },
@@ -6575,8 +6902,8 @@
         "turbolinks": "5.3.0-beta.1",
         "typescript": "^5.0.4",
         "uuid": "^9.0.0",
-        "vite": "^4.0.3",
-        "vite-plugin-ssr": "0.4.138"
+        "vike": "0.4.143",
+        "vite": "^4.0.3"
       },
       "dependencies": {
         "@esbuild/darwin-arm64": {
@@ -6993,6 +7320,7 @@
     },
     "@esbuild/darwin-arm64": {
       "version": "0.17.18",
+      "dev": true,
       "optional": true
     },
     "@esbuild/darwin-x64": {
@@ -8099,6 +8427,7 @@
     },
     "esbuild": {
       "version": "0.17.18",
+      "dev": true,
       "requires": {
         "@esbuild/android-arm": "0.17.18",
         "@esbuild/android-arm64": "0.17.18",
@@ -8128,126 +8457,147 @@
           "version": "0.17.18",
           "resolved": "https://registry.npmjs.org/@esbuild/android-arm/-/android-arm-0.17.18.tgz",
           "integrity": "sha512-EmwL+vUBZJ7mhFCs5lA4ZimpUH3WMAoqvOIYhVQwdIgSpHC8ImHdsRyhHAVxpDYUSm0lWvd63z0XH1IlImS2Qw==",
+          "dev": true,
           "optional": true
         },
         "@esbuild/android-arm64": {
           "version": "0.17.18",
           "resolved": "https://registry.npmjs.org/@esbuild/android-arm64/-/android-arm64-0.17.18.tgz",
           "integrity": "sha512-/iq0aK0eeHgSC3z55ucMAHO05OIqmQehiGay8eP5l/5l+iEr4EIbh4/MI8xD9qRFjqzgkc0JkX0LculNC9mXBw==",
+          "dev": true,
           "optional": true
         },
         "@esbuild/android-x64": {
           "version": "0.17.18",
           "resolved": "https://registry.npmjs.org/@esbuild/android-x64/-/android-x64-0.17.18.tgz",
           "integrity": "sha512-x+0efYNBF3NPW2Xc5bFOSFW7tTXdAcpfEg2nXmxegm4mJuVeS+i109m/7HMiOQ6M12aVGGFlqJX3RhNdYM2lWg==",
+          "dev": true,
           "optional": true
         },
         "@esbuild/darwin-x64": {
           "version": "0.17.18",
           "resolved": "https://registry.npmjs.org/@esbuild/darwin-x64/-/darwin-x64-0.17.18.tgz",
           "integrity": "sha512-Qq84ykvLvya3dO49wVC9FFCNUfSrQJLbxhoQk/TE1r6MjHo3sFF2tlJCwMjhkBVq3/ahUisj7+EpRSz0/+8+9A==",
+          "dev": true,
           "optional": true
         },
         "@esbuild/freebsd-arm64": {
           "version": "0.17.18",
           "resolved": "https://registry.npmjs.org/@esbuild/freebsd-arm64/-/freebsd-arm64-0.17.18.tgz",
           "integrity": "sha512-fw/ZfxfAzuHfaQeMDhbzxp9mc+mHn1Y94VDHFHjGvt2Uxl10mT4CDavHm+/L9KG441t1QdABqkVYwakMUeyLRA==",
+          "dev": true,
           "optional": true
         },
         "@esbuild/freebsd-x64": {
           "version": "0.17.18",
           "resolved": "https://registry.npmjs.org/@esbuild/freebsd-x64/-/freebsd-x64-0.17.18.tgz",
           "integrity": "sha512-FQFbRtTaEi8ZBi/A6kxOC0V0E9B/97vPdYjY9NdawyLd4Qk5VD5g2pbWN2VR1c0xhzcJm74HWpObPszWC+qTew==",
+          "dev": true,
           "optional": true
         },
         "@esbuild/linux-arm": {
           "version": "0.17.18",
           "resolved": "https://registry.npmjs.org/@esbuild/linux-arm/-/linux-arm-0.17.18.tgz",
           "integrity": "sha512-jW+UCM40LzHcouIaqv3e/oRs0JM76JfhHjCavPxMUti7VAPh8CaGSlS7cmyrdpzSk7A+8f0hiedHqr/LMnfijg==",
+          "dev": true,
           "optional": true
         },
         "@esbuild/linux-arm64": {
           "version": "0.17.18",
           "resolved": "https://registry.npmjs.org/@esbuild/linux-arm64/-/linux-arm64-0.17.18.tgz",
           "integrity": "sha512-R7pZvQZFOY2sxUG8P6A21eq6q+eBv7JPQYIybHVf1XkQYC+lT7nDBdC7wWKTrbvMXKRaGudp/dzZCwL/863mZQ==",
+          "dev": true,
           "optional": true
         },
         "@esbuild/linux-ia32": {
           "version": "0.17.18",
           "resolved": "https://registry.npmjs.org/@esbuild/linux-ia32/-/linux-ia32-0.17.18.tgz",
           "integrity": "sha512-ygIMc3I7wxgXIxk6j3V00VlABIjq260i967Cp9BNAk5pOOpIXmd1RFQJQX9Io7KRsthDrQYrtcx7QCof4o3ZoQ==",
+          "dev": true,
           "optional": true
         },
         "@esbuild/linux-loong64": {
           "version": "0.17.18",
           "resolved": "https://registry.npmjs.org/@esbuild/linux-loong64/-/linux-loong64-0.17.18.tgz",
           "integrity": "sha512-bvPG+MyFs5ZlwYclCG1D744oHk1Pv7j8psF5TfYx7otCVmcJsEXgFEhQkbhNW8otDHL1a2KDINW20cfCgnzgMQ==",
+          "dev": true,
           "optional": true
         },
         "@esbuild/linux-mips64el": {
           "version": "0.17.18",
           "resolved": "https://registry.npmjs.org/@esbuild/linux-mips64el/-/linux-mips64el-0.17.18.tgz",
           "integrity": "sha512-oVqckATOAGuiUOa6wr8TXaVPSa+6IwVJrGidmNZS1cZVx0HqkTMkqFGD2HIx9H1RvOwFeWYdaYbdY6B89KUMxA==",
+          "dev": true,
           "optional": true
         },
         "@esbuild/linux-ppc64": {
           "version": "0.17.18",
           "resolved": "https://registry.npmjs.org/@esbuild/linux-ppc64/-/linux-ppc64-0.17.18.tgz",
           "integrity": "sha512-3dLlQO+b/LnQNxgH4l9rqa2/IwRJVN9u/bK63FhOPB4xqiRqlQAU0qDU3JJuf0BmaH0yytTBdoSBHrb2jqc5qQ==",
+          "dev": true,
           "optional": true
         },
         "@esbuild/linux-riscv64": {
           "version": "0.17.18",
           "resolved": "https://registry.npmjs.org/@esbuild/linux-riscv64/-/linux-riscv64-0.17.18.tgz",
           "integrity": "sha512-/x7leOyDPjZV3TcsdfrSI107zItVnsX1q2nho7hbbQoKnmoeUWjs+08rKKt4AUXju7+3aRZSsKrJtaRmsdL1xA==",
+          "dev": true,
           "optional": true
         },
         "@esbuild/linux-s390x": {
           "version": "0.17.18",
           "resolved": "https://registry.npmjs.org/@esbuild/linux-s390x/-/linux-s390x-0.17.18.tgz",
           "integrity": "sha512-cX0I8Q9xQkL/6F5zWdYmVf5JSQt+ZfZD2bJudZrWD+4mnUvoZ3TDDXtDX2mUaq6upMFv9FlfIh4Gfun0tbGzuw==",
+          "dev": true,
           "optional": true
         },
         "@esbuild/linux-x64": {
           "version": "0.17.18",
           "resolved": "https://registry.npmjs.org/@esbuild/linux-x64/-/linux-x64-0.17.18.tgz",
           "integrity": "sha512-66RmRsPlYy4jFl0vG80GcNRdirx4nVWAzJmXkevgphP1qf4dsLQCpSKGM3DUQCojwU1hnepI63gNZdrr02wHUA==",
+          "dev": true,
           "optional": true
         },
         "@esbuild/netbsd-x64": {
           "version": "0.17.18",
           "resolved": "https://registry.npmjs.org/@esbuild/netbsd-x64/-/netbsd-x64-0.17.18.tgz",
           "integrity": "sha512-95IRY7mI2yrkLlTLb1gpDxdC5WLC5mZDi+kA9dmM5XAGxCME0F8i4bYH4jZreaJ6lIZ0B8hTrweqG1fUyW7jbg==",
+          "dev": true,
           "optional": true
         },
         "@esbuild/openbsd-x64": {
           "version": "0.17.18",
           "resolved": "https://registry.npmjs.org/@esbuild/openbsd-x64/-/openbsd-x64-0.17.18.tgz",
           "integrity": "sha512-WevVOgcng+8hSZ4Q3BKL3n1xTv5H6Nb53cBrtzzEjDbbnOmucEVcZeGCsCOi9bAOcDYEeBZbD2SJNBxlfP3qiA==",
+          "dev": true,
           "optional": true
         },
         "@esbuild/sunos-x64": {
           "version": "0.17.18",
           "resolved": "https://registry.npmjs.org/@esbuild/sunos-x64/-/sunos-x64-0.17.18.tgz",
           "integrity": "sha512-Rzf4QfQagnwhQXVBS3BYUlxmEbcV7MY+BH5vfDZekU5eYpcffHSyjU8T0xucKVuOcdCsMo+Ur5wmgQJH2GfNrg==",
+          "dev": true,
           "optional": true
         },
         "@esbuild/win32-arm64": {
           "version": "0.17.18",
           "resolved": "https://registry.npmjs.org/@esbuild/win32-arm64/-/win32-arm64-0.17.18.tgz",
           "integrity": "sha512-Kb3Ko/KKaWhjeAm2YoT/cNZaHaD1Yk/pa3FTsmqo9uFh1D1Rfco7BBLIPdDOozrObj2sahslFuAQGvWbgWldAg==",
+          "dev": true,
           "optional": true
         },
         "@esbuild/win32-ia32": {
           "version": "0.17.18",
           "resolved": "https://registry.npmjs.org/@esbuild/win32-ia32/-/win32-ia32-0.17.18.tgz",
           "integrity": "sha512-0/xUMIdkVHwkvxfbd5+lfG7mHOf2FRrxNbPiKWg9C4fFrB8H0guClmaM3BFiRUYrznVoyxTIyC/Ou2B7QQSwmw==",
+          "dev": true,
           "optional": true
         },
         "@esbuild/win32-x64": {
           "version": "0.17.18",
           "resolved": "https://registry.npmjs.org/@esbuild/win32-x64/-/win32-x64-0.17.18.tgz",
           "integrity": "sha512-qU25Ma1I3NqTSHJUOKi9sAH1/Mzuvlke0ioMJRthLXKm7JiSKVwFghlGbDLOO2sARECGhja4xYfRAZNPAkooYg==",
+          "dev": true,
           "optional": true
         }
       }
@@ -8430,7 +8780,9 @@
       },
       "dependencies": {
         "semver": {
-          "version": "7.5.0",
+          "version": "7.5.4",
+          "resolved": "https://registry.npmjs.org/semver/-/semver-7.5.4.tgz",
+          "integrity": "sha512-1bCSESV6Pv+i21Hvpxp3Dx+pSD8lIPt8uVjRrxAUt/nbswYc+tK6Y2btiULjd4+fnq15PX+nqQDC7Oft7WkwcA==",
           "requires": {
             "lru-cache": "^6.0.0"
           }
@@ -9151,7 +9503,9 @@
           }
         },
         "semver": {
-          "version": "5.7.1"
+          "version": "5.7.2",
+          "resolved": "https://registry.npmjs.org/semver/-/semver-5.7.2.tgz",
+          "integrity": "sha512-cBznnQ9KjJqU67B52RMC65CMarK2600WFnbkcaiwWq3xy/5haFJlshgnpjovMVJ+Hff49d8GEn0b87C5pDQ10g=="
         }
       }
     },
@@ -9322,7 +9676,9 @@
       "dev": true
     },
     "postcss": {
-      "version": "8.4.23",
+      "version": "8.4.31",
+      "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.4.31.tgz",
+      "integrity": "sha512-PS08Iboia9mts/2ygV3eLpY5ghnUcfLV/EXTOW1E2qYxJKGGBUtNjN76FYHnMs36RmARn41bC0AZmn+rR0OVpQ==",
       "requires": {
         "nanoid": "^3.3.6",
         "picocolors": "^1.0.0",
@@ -9641,7 +9997,9 @@
       "version": "1.3.0"
     },
     "rollup": {
-      "version": "3.20.7",
+      "version": "3.29.4",
+      "resolved": "https://registry.npmjs.org/rollup/-/rollup-3.29.4.tgz",
+      "integrity": "sha512-oWzmBZwvYrU0iJHtDmhsm662rC15FRXmcjCk1xD771dFDx5jJ02ufAQQTn0etB2emNk4J9EZg/yWKpsn9BWGRw==",
       "requires": {
         "fsevents": "~2.3.2"
       }
@@ -9716,7 +10074,9 @@
       "integrity": "sha512-mEugaLK+YfkijB4fx0e6kImuJdCIt2LxCRcbEYPqRGCs4F2ogyfZU5IAZRdjCP8JPq2AtdNoC/Dux63d9Kiryg=="
     },
     "semver": {
-      "version": "6.3.0",
+      "version": "6.3.1",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-6.3.1.tgz",
+      "integrity": "sha512-BR7VvDCVHO+q2xBEWskxS6DJE1qRnb7DxzUrogb71CWoSficBxYsiAGd+Kl0mmq/MprG9yArRkyrQxTO6XjMzA==",
       "dev": true
     },
     "send": {
@@ -10037,25 +10397,8 @@
         "nodemon": "^2.0.21",
         "ts-node": "^10.9.1",
         "uuid": "^9.0.0",
-        "vite": "^4.3.2",
-        "vite-plugin-ssr": "0.4.138"
-      },
-      "dependencies": {
-        "rollup": {
-          "version": "3.21.0",
-          "requires": {
-            "fsevents": "~2.3.2"
-          }
-        },
-        "vite": {
-          "version": "4.3.2",
-          "requires": {
-            "esbuild": "^0.17.5",
-            "fsevents": "~2.3.2",
-            "postcss": "^8.4.21",
-            "rollup": "^3.21.0"
-          }
-        }
+        "vike": "0.4.143",
+        "vite": "^4.3.2"
       }
     },
     "thenify": {
@@ -10111,9 +10454,9 @@
       }
     },
     "tough-cookie": {
-      "version": "4.1.2",
-      "resolved": "https://registry.npmjs.org/tough-cookie/-/tough-cookie-4.1.2.tgz",
-      "integrity": "sha512-G9fqXWoYFZgTc2z8Q5zaHy/vJMjm+WV0AkAeHxVCQiEB1b+dGvWzFW6QV07cY5jQ5gRkeid2qIkzkxUnmoQZUQ==",
+      "version": "4.1.3",
+      "resolved": "https://registry.npmjs.org/tough-cookie/-/tough-cookie-4.1.3.tgz",
+      "integrity": "sha512-aX/y5pVRkfRnfmuX+OdbSdXvPe6ieKX/G2s7e98f4poJHnqH3281gDPm/metm6E/WRamfx7WC4HUqkWHfQHprw==",
       "requires": {
         "psl": "^1.1.33",
         "punycode": "^2.1.1",
@@ -10177,15 +10520,6 @@
         "source-map": "0.8.0-beta.0",
         "sucrase": "^3.20.3",
         "tree-kill": "^1.2.2"
-      },
-      "dependencies": {
-        "rollup": {
-          "version": "3.21.3",
-          "dev": true,
-          "requires": {
-            "fsevents": "~2.3.2"
-          }
-        }
       }
     },
     "tunnel-agent": {
@@ -10291,18 +10625,9 @@
         }
       }
     },
-    "vite": {
-      "version": "4.3.1",
-      "requires": {
-        "esbuild": "^0.17.5",
-        "fsevents": "~2.3.2",
-        "postcss": "^8.4.21",
-        "rollup": "^3.20.2"
-      }
-    },
-    "vite-plugin-ssr": {
-      "version": "0.4.138",
-      "resolved": "https://registry.npmjs.org/vite-plugin-ssr/-/vite-plugin-ssr-0.4.138.tgz",
+    "vike": {
+      "version": "0.4.143",
+      "resolved": "https://registry.npmjs.org/vike/-/vike-0.4.143.tgz",
       "integrity": "sha512-ISaaB9sfKYo0i3bT9hP8ENgJdTFeMk6K68tToX0o/0B8ilklYol5Rekg6JSuMoUhZxPqEjSrudgJegSyhiwNoQ==",
       "requires": {
         "@brillout/import": "0.2.3",
@@ -10474,6 +10799,180 @@
             "@esbuild/win32-arm64": "0.17.19",
             "@esbuild/win32-ia32": "0.17.19",
             "@esbuild/win32-x64": "0.17.19"
+          }
+        }
+      }
+    },
+    "vite": {
+      "version": "4.4.11",
+      "resolved": "https://registry.npmjs.org/vite/-/vite-4.4.11.tgz",
+      "integrity": "sha512-ksNZJlkcU9b0lBwAGZGGaZHCMqHsc8OpgtoYhsQ4/I2v5cnpmmmqe5pM4nv/4Hn6G/2GhTdj0DhZh2e+Er1q5A==",
+      "requires": {
+        "esbuild": "^0.18.10",
+        "fsevents": "~2.3.2",
+        "postcss": "^8.4.27",
+        "rollup": "^3.27.1"
+      },
+      "dependencies": {
+        "@esbuild/android-arm": {
+          "version": "0.18.20",
+          "resolved": "https://registry.npmjs.org/@esbuild/android-arm/-/android-arm-0.18.20.tgz",
+          "integrity": "sha512-fyi7TDI/ijKKNZTUJAQqiG5T7YjJXgnzkURqmGj13C6dCqckZBLdl4h7bkhHt/t0WP+zO9/zwroDvANaOqO5Sw==",
+          "optional": true
+        },
+        "@esbuild/android-arm64": {
+          "version": "0.18.20",
+          "resolved": "https://registry.npmjs.org/@esbuild/android-arm64/-/android-arm64-0.18.20.tgz",
+          "integrity": "sha512-Nz4rJcchGDtENV0eMKUNa6L12zz2zBDXuhj/Vjh18zGqB44Bi7MBMSXjgunJgjRhCmKOjnPuZp4Mb6OKqtMHLQ==",
+          "optional": true
+        },
+        "@esbuild/android-x64": {
+          "version": "0.18.20",
+          "resolved": "https://registry.npmjs.org/@esbuild/android-x64/-/android-x64-0.18.20.tgz",
+          "integrity": "sha512-8GDdlePJA8D6zlZYJV/jnrRAi6rOiNaCC/JclcXpB+KIuvfBN4owLtgzY2bsxnx666XjJx2kDPUmnTtR8qKQUg==",
+          "optional": true
+        },
+        "@esbuild/darwin-arm64": {
+          "version": "0.18.20",
+          "resolved": "https://registry.npmjs.org/@esbuild/darwin-arm64/-/darwin-arm64-0.18.20.tgz",
+          "integrity": "sha512-bxRHW5kHU38zS2lPTPOyuyTm+S+eobPUnTNkdJEfAddYgEcll4xkT8DB9d2008DtTbl7uJag2HuE5NZAZgnNEA==",
+          "optional": true
+        },
+        "@esbuild/darwin-x64": {
+          "version": "0.18.20",
+          "resolved": "https://registry.npmjs.org/@esbuild/darwin-x64/-/darwin-x64-0.18.20.tgz",
+          "integrity": "sha512-pc5gxlMDxzm513qPGbCbDukOdsGtKhfxD1zJKXjCCcU7ju50O7MeAZ8c4krSJcOIJGFR+qx21yMMVYwiQvyTyQ==",
+          "optional": true
+        },
+        "@esbuild/freebsd-arm64": {
+          "version": "0.18.20",
+          "resolved": "https://registry.npmjs.org/@esbuild/freebsd-arm64/-/freebsd-arm64-0.18.20.tgz",
+          "integrity": "sha512-yqDQHy4QHevpMAaxhhIwYPMv1NECwOvIpGCZkECn8w2WFHXjEwrBn3CeNIYsibZ/iZEUemj++M26W3cNR5h+Tw==",
+          "optional": true
+        },
+        "@esbuild/freebsd-x64": {
+          "version": "0.18.20",
+          "resolved": "https://registry.npmjs.org/@esbuild/freebsd-x64/-/freebsd-x64-0.18.20.tgz",
+          "integrity": "sha512-tgWRPPuQsd3RmBZwarGVHZQvtzfEBOreNuxEMKFcd5DaDn2PbBxfwLcj4+aenoh7ctXcbXmOQIn8HI6mCSw5MQ==",
+          "optional": true
+        },
+        "@esbuild/linux-arm": {
+          "version": "0.18.20",
+          "resolved": "https://registry.npmjs.org/@esbuild/linux-arm/-/linux-arm-0.18.20.tgz",
+          "integrity": "sha512-/5bHkMWnq1EgKr1V+Ybz3s1hWXok7mDFUMQ4cG10AfW3wL02PSZi5kFpYKrptDsgb2WAJIvRcDm+qIvXf/apvg==",
+          "optional": true
+        },
+        "@esbuild/linux-arm64": {
+          "version": "0.18.20",
+          "resolved": "https://registry.npmjs.org/@esbuild/linux-arm64/-/linux-arm64-0.18.20.tgz",
+          "integrity": "sha512-2YbscF+UL7SQAVIpnWvYwM+3LskyDmPhe31pE7/aoTMFKKzIc9lLbyGUpmmb8a8AixOL61sQ/mFh3jEjHYFvdA==",
+          "optional": true
+        },
+        "@esbuild/linux-ia32": {
+          "version": "0.18.20",
+          "resolved": "https://registry.npmjs.org/@esbuild/linux-ia32/-/linux-ia32-0.18.20.tgz",
+          "integrity": "sha512-P4etWwq6IsReT0E1KHU40bOnzMHoH73aXp96Fs8TIT6z9Hu8G6+0SHSw9i2isWrD2nbx2qo5yUqACgdfVGx7TA==",
+          "optional": true
+        },
+        "@esbuild/linux-loong64": {
+          "version": "0.18.20",
+          "resolved": "https://registry.npmjs.org/@esbuild/linux-loong64/-/linux-loong64-0.18.20.tgz",
+          "integrity": "sha512-nXW8nqBTrOpDLPgPY9uV+/1DjxoQ7DoB2N8eocyq8I9XuqJ7BiAMDMf9n1xZM9TgW0J8zrquIb/A7s3BJv7rjg==",
+          "optional": true
+        },
+        "@esbuild/linux-mips64el": {
+          "version": "0.18.20",
+          "resolved": "https://registry.npmjs.org/@esbuild/linux-mips64el/-/linux-mips64el-0.18.20.tgz",
+          "integrity": "sha512-d5NeaXZcHp8PzYy5VnXV3VSd2D328Zb+9dEq5HE6bw6+N86JVPExrA6O68OPwobntbNJ0pzCpUFZTo3w0GyetQ==",
+          "optional": true
+        },
+        "@esbuild/linux-ppc64": {
+          "version": "0.18.20",
+          "resolved": "https://registry.npmjs.org/@esbuild/linux-ppc64/-/linux-ppc64-0.18.20.tgz",
+          "integrity": "sha512-WHPyeScRNcmANnLQkq6AfyXRFr5D6N2sKgkFo2FqguP44Nw2eyDlbTdZwd9GYk98DZG9QItIiTlFLHJHjxP3FA==",
+          "optional": true
+        },
+        "@esbuild/linux-riscv64": {
+          "version": "0.18.20",
+          "resolved": "https://registry.npmjs.org/@esbuild/linux-riscv64/-/linux-riscv64-0.18.20.tgz",
+          "integrity": "sha512-WSxo6h5ecI5XH34KC7w5veNnKkju3zBRLEQNY7mv5mtBmrP/MjNBCAlsM2u5hDBlS3NGcTQpoBvRzqBcRtpq1A==",
+          "optional": true
+        },
+        "@esbuild/linux-s390x": {
+          "version": "0.18.20",
+          "resolved": "https://registry.npmjs.org/@esbuild/linux-s390x/-/linux-s390x-0.18.20.tgz",
+          "integrity": "sha512-+8231GMs3mAEth6Ja1iK0a1sQ3ohfcpzpRLH8uuc5/KVDFneH6jtAJLFGafpzpMRO6DzJ6AvXKze9LfFMrIHVQ==",
+          "optional": true
+        },
+        "@esbuild/linux-x64": {
+          "version": "0.18.20",
+          "resolved": "https://registry.npmjs.org/@esbuild/linux-x64/-/linux-x64-0.18.20.tgz",
+          "integrity": "sha512-UYqiqemphJcNsFEskc73jQ7B9jgwjWrSayxawS6UVFZGWrAAtkzjxSqnoclCXxWtfwLdzU+vTpcNYhpn43uP1w==",
+          "optional": true
+        },
+        "@esbuild/netbsd-x64": {
+          "version": "0.18.20",
+          "resolved": "https://registry.npmjs.org/@esbuild/netbsd-x64/-/netbsd-x64-0.18.20.tgz",
+          "integrity": "sha512-iO1c++VP6xUBUmltHZoMtCUdPlnPGdBom6IrO4gyKPFFVBKioIImVooR5I83nTew5UOYrk3gIJhbZh8X44y06A==",
+          "optional": true
+        },
+        "@esbuild/openbsd-x64": {
+          "version": "0.18.20",
+          "resolved": "https://registry.npmjs.org/@esbuild/openbsd-x64/-/openbsd-x64-0.18.20.tgz",
+          "integrity": "sha512-e5e4YSsuQfX4cxcygw/UCPIEP6wbIL+se3sxPdCiMbFLBWu0eiZOJ7WoD+ptCLrmjZBK1Wk7I6D/I3NglUGOxg==",
+          "optional": true
+        },
+        "@esbuild/sunos-x64": {
+          "version": "0.18.20",
+          "resolved": "https://registry.npmjs.org/@esbuild/sunos-x64/-/sunos-x64-0.18.20.tgz",
+          "integrity": "sha512-kDbFRFp0YpTQVVrqUd5FTYmWo45zGaXe0X8E1G/LKFC0v8x0vWrhOWSLITcCn63lmZIxfOMXtCfti/RxN/0wnQ==",
+          "optional": true
+        },
+        "@esbuild/win32-arm64": {
+          "version": "0.18.20",
+          "resolved": "https://registry.npmjs.org/@esbuild/win32-arm64/-/win32-arm64-0.18.20.tgz",
+          "integrity": "sha512-ddYFR6ItYgoaq4v4JmQQaAI5s7npztfV4Ag6NrhiaW0RrnOXqBkgwZLofVTlq1daVTQNhtI5oieTvkRPfZrePg==",
+          "optional": true
+        },
+        "@esbuild/win32-ia32": {
+          "version": "0.18.20",
+          "resolved": "https://registry.npmjs.org/@esbuild/win32-ia32/-/win32-ia32-0.18.20.tgz",
+          "integrity": "sha512-Wv7QBi3ID/rROT08SABTS7eV4hX26sVduqDOTe1MvGMjNd3EjOz4b7zeexIR62GTIEKrfJXKL9LFxTYgkyeu7g==",
+          "optional": true
+        },
+        "@esbuild/win32-x64": {
+          "version": "0.18.20",
+          "resolved": "https://registry.npmjs.org/@esbuild/win32-x64/-/win32-x64-0.18.20.tgz",
+          "integrity": "sha512-kTdfRcSiDfQca/y9QIkng02avJ+NCaQvrMejlsB3RRv5sE9rRoeBPISaZpKxHELzRxZyLvNts1P27W3wV+8geQ==",
+          "optional": true
+        },
+        "esbuild": {
+          "version": "0.18.20",
+          "resolved": "https://registry.npmjs.org/esbuild/-/esbuild-0.18.20.tgz",
+          "integrity": "sha512-ceqxoedUrcayh7Y7ZX6NdbbDzGROiyVBgC4PriJThBKSVPWnnFHZAkfI1lJT8QFkOwH4qOS2SJkS4wvpGl8BpA==",
+          "requires": {
+            "@esbuild/android-arm": "0.18.20",
+            "@esbuild/android-arm64": "0.18.20",
+            "@esbuild/android-x64": "0.18.20",
+            "@esbuild/darwin-arm64": "0.18.20",
+            "@esbuild/darwin-x64": "0.18.20",
+            "@esbuild/freebsd-arm64": "0.18.20",
+            "@esbuild/freebsd-x64": "0.18.20",
+            "@esbuild/linux-arm": "0.18.20",
+            "@esbuild/linux-arm64": "0.18.20",
+            "@esbuild/linux-ia32": "0.18.20",
+            "@esbuild/linux-loong64": "0.18.20",
+            "@esbuild/linux-mips64el": "0.18.20",
+            "@esbuild/linux-ppc64": "0.18.20",
+            "@esbuild/linux-riscv64": "0.18.20",
+            "@esbuild/linux-s390x": "0.18.20",
+            "@esbuild/linux-x64": "0.18.20",
+            "@esbuild/netbsd-x64": "0.18.20",
+            "@esbuild/openbsd-x64": "0.18.20",
+            "@esbuild/sunos-x64": "0.18.20",
+            "@esbuild/win32-arm64": "0.18.20",
+            "@esbuild/win32-ia32": "0.18.20",
+            "@esbuild/win32-x64": "0.18.20"
           }
         }
       }

--- a/package-lock.json
+++ b/package-lock.json
@@ -16,7 +16,7 @@
     },
     "bifrost": {
       "name": "@alignable/bifrost",
-      "version": "0.0.27",
+      "version": "0.0.28",
       "dependencies": {
         "cross-env": "^7.0.3",
         "jsdom": "^22.1.0",
@@ -47,7 +47,7 @@
     },
     "bifrost-fastify": {
       "name": "@alignable/bifrost-fastify",
-      "version": "0.0.27",
+      "version": "0.0.28",
       "dependencies": {
         "@fastify/accepts": "^4.1.0",
         "@fastify/forwarded": "^2.2.0",
@@ -73,7 +73,7 @@
         "typescript": "^5.0.4"
       },
       "peerDependencies": {
-        "@alignable/bifrost": "0.0.27",
+        "@alignable/bifrost": "0.0.28",
         "fastify": "^4.9.2",
         "vike": "0.4.143"
       }

--- a/tests/e2e/playwright.config.ts
+++ b/tests/e2e/playwright.config.ts
@@ -85,17 +85,17 @@ export default defineConfig({
   /* Run your local dev server before starting the tests */
   webServer: [
     {
-      command: "cd ../vite && PORT=5555 yarn dev",
+      command: "cd ../vite && PORT=5555 npm run dev",
       reuseExistingServer: true,
       port: 5555,
     },
     {
-      command: "cd ../fake-backend && PORT=5557 yarn start",
+      command: "cd ../fake-backend && PORT=5557 npm run start",
       reuseExistingServer: true,
       port: 5557,
     },
     {
-      command: "cd ../alb && yarn start",
+      command: "cd ../alb && npm run start",
       reuseExistingServer: true,
       port: 5050,
     },

--- a/tests/fake-backend/index.ts
+++ b/tests/fake-backend/index.ts
@@ -9,7 +9,7 @@ function sleep(timeout: number) {
     setTimeout(resolve, timeout);
   });
 }
-app.use(morgan("tiny"));
+// app.use(morgan("tiny"));
 
 app.get(["/custom", "/custom-:id"], async (req, res) => {
   const data = JSON.parse(req.query.page as string) as PageData;
@@ -28,7 +28,6 @@ app.get(["/custom", "/custom-:id"], async (req, res) => {
   } else {
     res.status(200);
     if (req.header("X-VITE-PROXY")) {
-      console.log("layout", data.layout);
       res.setHeader("X-REACT-LAYOUT", data.layout ?? "main_nav");
       res.setHeader("X-REACT-CURRENT-NAV", "home_page");
     }

--- a/tests/vite/assert-server.ts
+++ b/tests/vite/assert-server.ts
@@ -1,0 +1,29 @@
+import type { Plugin } from "vite";
+import path from "path";
+
+const PLUGIN_NAME = "assert-server";
+
+export default function assertServer(): Plugin {
+  return {
+    name: PLUGIN_NAME,
+    enforce: "pre",
+    resolveId(src, importer, options) {
+      if (src.endsWith(".server") && !options?.ssr) {
+        const fullPath = path.join(importer || "", src);
+        this.error({
+          plugin: PLUGIN_NAME,
+          pluginCode: "SERVER_FILE_IN_CLIENT_BUNDLE",
+          message: `${fullPath} included in client bundle. Imported by ${importer}`,
+        });
+      }
+      if (src.endsWith(".client") && options?.ssr) {
+        const fullPath = path.join(importer || "", src);
+        this.error({
+          plugin: PLUGIN_NAME,
+          pluginCode: "CLIENT_FILE_IN_BUNDLE",
+          message: `${fullPath} included in server bundle. Imported by ${importer}`,
+        });
+      }
+    },
+  };
+}

--- a/tests/vite/package.json
+++ b/tests/vite/package.json
@@ -4,10 +4,10 @@
   "description": "",
   "scripts": {
     "dev": "nodemon server/index.ts | npx pino-pretty",
-    "start": "yarn node dist/server/index.js",
-    "build": "yarn build:server && yarn build:vite",
+    "start": "node dist/server/index.js",
+    "build": "npm run build:server && npm run build:vite",
     "build:vite": "vite build --outDir dist/vite",
-    "build:server": "yarn tsc -p tsconfig-build.json"
+    "build:server": "npm run tsc -p tsconfig-build.json"
   },
   "type": "module",
   "author": "",
@@ -22,7 +22,7 @@
     "ts-node": "^10.9.1",
     "uuid": "^9.0.0",
     "vite": "^4.3.2",
-    "vite-plugin-ssr": "0.4.138"
+    "vike": "0.4.143"
   },
   "devDependencies": {
     "@types/uuid": "^9.0.1"

--- a/tests/vite/pages/custom-route-page/+route.ts
+++ b/tests/vite/pages/custom-route-page/+route.ts
@@ -1,4 +1,4 @@
-import type { PageContextBuiltIn } from "vite-plugin-ssr/types";
+import type { PageContextBuiltIn } from "vike/types";
 
 const ROUTES = ["/this-is-a-custom-route"];
 export default function route(pageContext: PageContextBuiltIn) {

--- a/tests/vite/proxy/pages/+route.ts
+++ b/tests/vite/proxy/pages/+route.ts
@@ -1,4 +1,4 @@
-import { PageContextBuiltIn } from "vite-plugin-ssr/types";
+import { PageContextBuiltIn } from "vike/types";
 
 const paths = ["/custom", "/custom-bifrost", "/json-route"];
 

--- a/tests/vite/server/index.ts
+++ b/tests/vite/server/index.ts
@@ -1,4 +1,4 @@
-// Note that this file isn't processed by Vite, see https://github.com/brillout/vite-plugin-ssr/issues/562
+// Note that this file isn't processed by Vite, see https://github.com/brillout/vike/issues/562
 import compress from "@fastify/compress";
 import middie from "@fastify/middie";
 import fastifyStatic from "@fastify/static";
@@ -18,7 +18,7 @@ const UPSTREAM = new URL("http://localhost:5557"); //new URL("http://dev.alignab
 const HOST = new URL("http://localhost:5050");
 
 async function startServer() {
-  const app = fastify({ logger: { level: "info" } });
+  const app = fastify({ logger: { level: process.env.LOG_LEVEL || "info" } });
 
   await app.register(middie);
   await app.register(compress);

--- a/tests/vite/vite.config.ts
+++ b/tests/vite/vite.config.ts
@@ -1,5 +1,5 @@
 import react from "@vitejs/plugin-react";
-import ssr from "vite-plugin-ssr/plugin";
+import ssr from "vike/plugin";
 import { UserConfig } from "vite";
 
 const config: UserConfig = {


### PR DESCRIPTION
Upgrade to 0.4.143 and follow the VPS rebrand from vite-plugin-ssr to vike.

Notably, 0.4.142 contains the[ performance improvements to URL parsing](https://github.com/vikejs/vike/issues/1115) which is important to bifrost as we pay the routing overhead cost even on requests that get proxied to legacy backend (cause we check "can bifrost handle this request" before going to legacy backend).