### PR TITLE
Handle HEAD Requests

### DIFF
--- a/bifrost-fastify/index.ts
+++ b/bifrost-fastify/index.ts
@@ -121,7 +121,10 @@ export const viteProxyPlugin: FastifyPluginAsync<
     upstream: upstream.href,
     websocket: true,
     async preHandler(req, reply) {
-      if (req.method === "GET" && req.accepts().type(["html"]) === "html") {
+      if (
+        (req.method === "GET" || req.method === "HEAD") &&
+        req.accepts().type(["html"]) === "html"
+      ) {
         const pageContextInit = {
           urlOriginal: req.url,
           ...(buildPageContextInit ? await buildPageContextInit(req) : {}),

--- a/tests/e2e/specs/http.spec.ts
+++ b/tests/e2e/specs/http.spec.ts
@@ -9,6 +9,27 @@ test.describe("requests", () => {
     );
   });
 
+  test.describe("HEAD request", () => {
+    test("returns headers for vite page", async ({ request }) => {
+      const req = await request.head("./vite-page");
+      expect(req.headers()).toMatchObject({
+        "x-test-pageid": "/pages/vite-page",
+      });
+      expect(req.headers()).not.toMatchObject({
+        "x-test-fake-backend": "1",
+      });
+    });
+
+    test("returns headers for proxied page", async ({ request }) => {
+      const req = await request.head("./custom-incorrect");
+      expect(req.headers()).toMatchObject({
+        "x-test-pageid": "/proxy/pages/passthru",
+        // hits old backend
+        "x-test-fake-backend": "1",
+      });
+    });
+  });
+
   test.describe("onError", () => {
     test("returns header that we set in onError", async ({ request }) => {
       const req = await request.get("./broken-page");

--- a/tests/fake-backend/index.ts
+++ b/tests/fake-backend/index.ts
@@ -4,6 +4,11 @@ import { PageData, buildPage, toPath } from "./page-builder";
 const app = express();
 const port = 5557;
 
+app.use(function (req, res, next) {
+  res.setHeader("x-test-fake-backend", "1");
+  next();
+});
+
 function sleep(timeout: number) {
   return new Promise(function (resolve) {
     setTimeout(resolve, timeout);


### PR DESCRIPTION
Fixes bug where HEAD requests to Vite pages would forward request to passthru proxy instead of just handling it by returning headers.
