### PR TITLE
Fix error message leaking into error page

### DIFF
--- a/bifrost/renderer/wrapped/onAfterRenderHtml.ts
+++ b/bifrost/renderer/wrapped/onAfterRenderHtml.ts
@@ -1,5 +1,4 @@
 import { PageContextServer } from "vike/types";
-import { render } from "vike/abort";
 
 export default function wrappedOnAfterRenderHtml(
   pageContext: PageContextServer
@@ -9,8 +8,7 @@ export default function wrappedOnAfterRenderHtml(
     !pageContext._wrappedServerOnly.renderedBody
   ) {
     // We set wrapped serverOnly but we never rendered the body
-    throw render(
-      500,
+    throw new Error(
       "proxied-body not found in DOM after SSR. This likely means the Layout threw during SSR (e.g. accessing `window` or `document`). Fix the SSR error in your Layout component."
     );
   }


### PR DESCRIPTION
Fixes this error message leaking into the error page. `throw render` should only be used as intentional control flow, not for errors. `abortReason` should be treated as user facing. So fixing this by throwing an error instead of `throw render`

<img width="3436" height="2000" alt="Screenshot 2026-04-22 at 8 37 17 PM" src="https://github.com/user-attachments/assets/d94e2f78-0957-4ff6-9cae-9990941724f8" />

This error still results in a 500 error based on existing tests.
