### PR TITLE
Fix throw render() history nav

### DIFF
--- a/bifrost/renderer/onBeforeRoute.ts
+++ b/bifrost/renderer/onBeforeRoute.ts
@@ -11,16 +11,28 @@ const onBeforeRoute = (pageContext: PageContext) => {
     let currentVisit = pageContext._turbolinksVisit;
 
     if (pageContext.isHistoryNavigation) {
+      if (!pageContext.pageContextsAborted?.length) {
+        // This can be called multiple times if guards throw redirect, only notify history pop once
+        Turbolinks.controller.historyPoppedToLocationWithRestorationIdentifier(
+          pageContext.urlOriginal,
+          ""
+        );
+      }
+      // Initially, currentVisit was just created by historyPoppedToLocationWithRestorationIdentifier
+      // If abort rendering, we'd rather Vike pass _turbolinksVisit, but it does not, so we recover from Turbolinks global
+      // There is risk of race condition if a history nav and a regular nav happen at the same time.
+      currentVisit = Turbolinks.controller.currentVisit;
+    }
+
+    if (pageContext.pageContextsAborted?.length && currentVisit) {
+      currentVisit.updateIfRedirect(pageContext.urlOriginal);
+    }
+
+    if (pageContext.isHistoryNavigation) {
       const snapshot = Turbolinks.controller.getCachedSnapshotForLocation(
         pageContext.urlOriginal
       );
-      Turbolinks.controller.historyPoppedToLocationWithRestorationIdentifier(
-        pageContext.urlOriginal,
-        ""
-      );
 
-      // currentVisit was just created by historyPoppedToLocationWithRestorationIdentifier
-      currentVisit = Turbolinks.controller.currentVisit;
       if (!!snapshot) {
         return {
           pageContext: {
@@ -29,8 +41,6 @@ const onBeforeRoute = (pageContext: PageContext) => {
           },
         };
       }
-    } else if (pageContext.pageContextsAborted && currentVisit) {
-      currentVisit.updateIfRedirect(pageContext.urlOriginal);
     }
     return { pageContext: { _turbolinksVisit: currentVisit } };
   }

--- a/tests/e2e/specs/e2e.spec.ts
+++ b/tests/e2e/specs/e2e.spec.ts
@@ -4,6 +4,7 @@ import {
   expectNoMoreScripts,
   ensureNoBrowserNavigation,
   storeConsoleLog,
+  waitForConsoleLog,
   validateDOMOnTurbolinks,
   StringMatcher,
   sleep,
@@ -81,6 +82,44 @@ test.describe("pages", () => {
     await expect(
       page.locator("nav", { hasText: "Main Nav Layout" })
     ).toHaveCount(1);
+  });
+
+  test("back button to a page proxied by render() fires each turbolinks event once", async ({
+    page,
+  }) => {
+    ensureAllNetworkSucceeds(page);
+    await page.goto("./proxy-to", { waitUntil: "networkidle" });
+    await waitForTurbolinksInit(page);
+    await expect(page).toHaveTitle("b");
+
+    await ensureNoBrowserNavigation(page, async () => {
+      const loaded = waitForConsoleLog(page, (m) => m.text() === T.load);
+      await page.getByText("vite page").click();
+      await loaded;
+    });
+    await expect(page).toHaveTitle("vite page");
+
+    // capture only the events from the back navigation
+    const logs = storeConsoleLog(page);
+    await ensureNoBrowserNavigation(page, async () => {
+      const loaded = waitForConsoleLog(page, (m) => m.text() === T.load);
+      await page.goBack();
+      await loaded;
+    });
+
+    await expect(page).toHaveTitle("b");
+    await expect(
+      page.locator("nav", { hasText: "Main Nav Layout" })
+    ).toHaveCount(1);
+
+    // restoration visits skip click/before-visit, and each event fires exactly once
+    expect(logs.filter((s) => s.startsWith("turbolinks:"))).toEqual([
+      T.visit,
+      T.beforeRender,
+      T.render,
+      T.load,
+    ]);
+    await expectNoMoreScripts(page);
   });
 
   test("it serves vite pages", async ({ page }) => {

--- a/tests/vite/pages/vite-page/+Page.tsx
+++ b/tests/vite/pages/vite-page/+Page.tsx
@@ -44,6 +44,7 @@ export default function Page() {
       <a href="/redirect-page/redirect-to">redirect page</a>
       <a href="#anchor">anchor link</a>
       <h2 id="anchor">anchor link test</h2>
+      <a href="/proxy-to">proxy-to page</a>
       <div style={{ height: "1000px" }}></div>
     </>
   );


### PR DESCRIPTION
When making a history navigation to a route that calls `throw render()` we call `historyPoppedToLocationWithRestorationIdentifier` twice, once on the original visit and again on each abort-render. This triggers two `turbolinks:visit` events and causes multiple Visits to be created, rather than updating `redirectedToLocation` on the existing Visit. This breaks Turbolinks invariant which may lead to bugs on the mobile app and race conditions.